### PR TITLE
fix(library): paginate getAlbumList2 to show all albums

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@poutine/frontend",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/subsonic.ts
+++ b/frontend/src/lib/subsonic.ts
@@ -230,15 +230,26 @@ export async function getAlbumList2(params?: {
   type?: string;
   size?: number;
 }): Promise<SubsonicAlbum[]> {
-  const sr = await subsonicFetch<{ albumList2: { album?: RawAlbum[] } }>(
-    "getAlbumList2",
-    {
-      type: params?.type ?? "alphabeticalByName",
-      size: String(params?.size ?? 500),
-      offset: "0",
-    },
-  );
-  return (sr.albumList2.album ?? []).map(parseAlbum);
+  const type = params?.type ?? "alphabeticalByName";
+  const pageSize = Math.min(params?.size ?? 500, 500);
+  const all: RawAlbum[] = [];
+  let offset = 0;
+  // Subsonic caps getAlbumList2 at 500 per call; page until a short page returns.
+  for (;;) {
+    const sr = await subsonicFetch<{ albumList2: { album?: RawAlbum[] } }>(
+      "getAlbumList2",
+      {
+        type,
+        size: String(pageSize),
+        offset: String(offset),
+      },
+    );
+    const page = sr.albumList2.album ?? [];
+    all.push(...page);
+    if (page.length < pageSize) break;
+    offset += pageSize;
+  }
+  return all.map(parseAlbum);
 }
 
 export async function getArtists(): Promise<SubsonicArtist[]> {

--- a/hub/package.json
+++ b/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poutine/hub",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/hub/src/version.ts
+++ b/hub/src/version.ts
@@ -15,7 +15,7 @@
  *   3. Update contract tests in hub/test/federation-routes.test.ts
  */
 
-export const APP_VERSION = "0.3.0";
+export const APP_VERSION = "0.3.1";
 export const FEDERATION_API_VERSION = 3;
 
 /** User-Agent header value sent on all outgoing federation requests. */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poutine",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.1",
   "description": "Federated music player - merges personal music collections into a unified library",
   "scripts": {
     "dev": "pnpm --filter hub dev",


### PR DESCRIPTION
## Summary
- Library page was capped at 500 albums (Subsonic `getAlbumList2` per-page limit). Combined libraries >500 albums got truncated alphabetically around "T".
- `getAlbumList2` helper now pages through `offset` until a short page returns, concatenating results.

Closes #45

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (232 passing)
- [x] Manual: load Library with >500-album combined collection, confirm albums past "T" appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)