### PR TITLE
fix: enforce minimum federation API version at peering (closes #5)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -136,11 +136,14 @@ export interface Peer {
   trackCount: number;
   artistCount: number;
   albumCount: number;
+  appVersion: string | null;
+  apiVersion: number | null;
 }
 
 export interface InstanceInfo {
   instanceId: string;
   publicKey: string;
+  apiVersion: number;
   navidrome: {
     reachable: boolean;
     scanning: boolean;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -113,6 +113,14 @@ function InstanceSection() {
 
         <div className="flex items-center gap-2">
           <Activity className="w-4 h-4 text-text-muted shrink-0" />
+          <span className="text-xs text-text-secondary uppercase tracking-wide font-medium">Federation API Version</span>
+        </div>
+        <div className="flex items-center gap-2 pl-6">
+          <code className="flex-1 text-sm text-text-primary font-mono bg-surface-hover px-2 py-1 rounded">{info.apiVersion}</code>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Activity className="w-4 h-4 text-text-muted shrink-0" />
           <span className="text-xs text-text-secondary uppercase tracking-wide font-medium">Public Key</span>
         </div>
         <div className="flex items-center gap-2 pl-6">
@@ -227,6 +235,12 @@ function PeerRow({ peer }: { peer: Peer }) {
             </span>
           </div>
           <p className="text-xs text-text-muted truncate">{peer.url}</p>
+          {(peer.appVersion || peer.apiVersion) && (
+            <p className="text-xs text-text-muted truncate">
+              {peer.appVersion ? `v${peer.appVersion}` : "unknown version"}
+              {peer.apiVersion !== null ? ` · api ${peer.apiVersion}` : ""}
+            </p>
+          )}
         </div>
         <div className="hidden sm:block text-xs text-text-secondary shrink-0">
           {peer.lastSeen ? `Last seen ${formatTimeAgo(peer.lastSeen)}` : "Never synced"}

--- a/hub/src/federation/peer-auth.ts
+++ b/hub/src/federation/peer-auth.ts
@@ -8,11 +8,23 @@ declare module "fastify" {
   }
 }
 
+/**
+ * Minimum accepted federation API version.
+ * Peers advertising an apiVersion below this floor will be rejected.
+ * May be disabled via POUTINE_DISABLE_VERSION_CHECK=true for testing/migration.
+ */
+const MIN_FEDERATION_API_VERSION = 3;
+
 export function createRequirePeerAuth(deps: {
   registry: PeerRegistry;
+  db: { prepare(sql: string): { run(instanceId: string, serverVersion: string): void } };
   maxSkewMs?: number;
 }): (request: FastifyRequest, reply: FastifyReply) => Promise<void> {
   const maxSkewMs = deps.maxSkewMs ?? 5 * 60 * 1000;
+  const versionCheckEnabled = process.env.POUTINE_DISABLE_VERSION_CHECK !== "true";
+  const upsertServerVersion = deps.db.prepare(
+    "UPDATE instances SET server_version = ? WHERE id = ?",
+  );
 
   return async function requirePeerAuth(
     request: FastifyRequest,
@@ -22,6 +34,7 @@ export function createRequirePeerAuth(deps: {
     const userHeader = request.headers["x-poutine-user"];
     const timestampHeader = request.headers["x-poutine-timestamp"];
     const signatureHeader = request.headers["x-poutine-signature"];
+    const apiVersionHeader = request.headers["poutine-api-version"];
 
     if (!instanceHeader || !userHeader || !timestampHeader || !signatureHeader) {
       reply.code(401).send({ error: "Missing required federation headers" });
@@ -37,6 +50,25 @@ export function createRequirePeerAuth(deps: {
     if (!peer) {
       reply.code(401).send({ error: `Unknown peer: ${instanceId}` });
       return;
+    }
+
+    // ── Phase 3: version enforcement ─────────────────────────────────────────
+    if (versionCheckEnabled) {
+      const rawVersion = Array.isArray(apiVersionHeader)
+        ? apiVersionHeader[0]
+        : apiVersionHeader;
+      const peerApiVersion = rawVersion !== undefined ? parseInt(String(rawVersion), 10) : NaN;
+
+      if (isNaN(peerApiVersion) || peerApiVersion < MIN_FEDERATION_API_VERSION) {
+        const gotVersion = isNaN(peerApiVersion) ? "(none)" : String(peerApiVersion);
+        reply.code(403).send({
+          error: `Peer ${instanceId} apiVersion ${gotVersion} is below minimum required ${MIN_FEDERATION_API_VERSION}`,
+        });
+        return;
+      }
+
+      // Store the peer's reported version in the instances table for display.
+      upsertServerVersion.run(String(peerApiVersion), instanceId);
     }
 
     const ts = parseInt(timestamp, 10);

--- a/hub/src/federation/sign-request.ts
+++ b/hub/src/federation/sign-request.ts
@@ -5,7 +5,7 @@ import {
   signRequest,
 } from "./signing.js";
 import type { Peer } from "./peers.js";
-import { USER_AGENT } from "../version.js";
+import { USER_AGENT, FEDERATION_API_VERSION } from "../version.js";
 
 export interface FederatedFetchOptions {
   method?: string; // default GET
@@ -52,6 +52,7 @@ export function createFederationFetcher(deps: {
       "x-poutine-user": opts.asUser,
       "x-poutine-timestamp": timestamp,
       "x-poutine-signature": signature,
+      "poutine-api-version": String(FEDERATION_API_VERSION),
     };
 
     if (opts.body) {

--- a/hub/src/proxy/auth.ts
+++ b/hub/src/proxy/auth.ts
@@ -12,6 +12,7 @@
 
 import crypto from "node:crypto";
 import type { FastifyRequest, FastifyReply } from "fastify";
+import { FEDERATION_API_VERSION } from "../version.js";
 import { canonicalSigningPayload, verifyRequest } from "../federation/signing.js";
 import { verifyToken } from "../auth/jwt.js";
 import { verifyPassword } from "../auth/passwords.js";
@@ -98,6 +99,24 @@ export function createRequireProxyAuth(deps: {
       if (!verifyRequest(peer.publicKey, payload, signature)) {
         reply.code(401).send({ error: "Invalid signature" });
         return;
+      }
+
+      // Enforce minimum federation API version
+      const versionCheckEnabled = process.env.POUTINE_DISABLE_VERSION_CHECK !== "true";
+      if (versionCheckEnabled) {
+        const apiVersionHeader = request.headers["poutine-api-version"];
+        const rawVersion = Array.isArray(apiVersionHeader)
+          ? apiVersionHeader[0]
+          : apiVersionHeader;
+        const peerApiVersion = rawVersion !== undefined ? parseInt(String(rawVersion), 10) : NaN;
+
+        if (isNaN(peerApiVersion) || peerApiVersion < FEDERATION_API_VERSION) {
+          const gotVersion = isNaN(peerApiVersion) ? "(none)" : String(peerApiVersion);
+          reply.code(403).send({
+            error: `Peer ${instanceId} apiVersion ${gotVersion} is below minimum required ${FEDERATION_API_VERSION}`,
+          });
+          return;
+        }
       }
 
       request.proxyAuth = { kind: "peer", peerId: instanceId };

--- a/hub/src/routes/admin.ts
+++ b/hub/src/routes/admin.ts
@@ -6,7 +6,7 @@ import { SyncOperationService } from "../services/sync-operations.js";
 import { StreamTrackingService } from "../services/stream-tracking.js";
 import { mergeLibraries } from "../library/merge.js";
 import { SubsonicClient } from "../adapters/subsonic.js";
-import { USER_AGENT } from "../version.js";
+import { FEDERATION_API_VERSION, USER_AGENT } from "../version.js";
 
 declare module "fastify" {
   interface FastifyRequest {
@@ -271,6 +271,7 @@ export const adminRoutes: FastifyPluginAsync = async (app) => {
     return {
       instanceId: app.config.poutineInstanceId,
       publicKey: app.publicKeySpec,
+      apiVersion: FEDERATION_API_VERSION,
       navidrome: {
         reachable: scanStatus !== null,
         scanning: scanStatus?.scanning ?? false,

--- a/hub/src/routes/federation.ts
+++ b/hub/src/routes/federation.ts
@@ -9,6 +9,7 @@ import type { FastifyPluginAsync } from "fastify";
 import http from "node:http";
 import https from "node:https";
 import { pipeline } from "node:stream/promises";
+import { createRequirePeerAuth } from "../federation/peer-auth.js";
 
 // ── HTTP agents for upstream requests ────────────────────────────────────────
 
@@ -27,12 +28,16 @@ const httpsAgent = new https.Agent({
 // ── Plugin ────────────────────────────────────────────────────────────────────
 
 export const federationRoutes: FastifyPluginAsync = async (app) => {
-  const config = app.config;
+  const requirePeerAuth = createRequirePeerAuth({
+    registry: app.peerRegistry,
+    db: app.db,
+  });
 
   // Stream audio from local Navidrome to peer
-  app.get("/stream/:id", async (request, reply) => {
+  app.get("/stream/:id", { preHandler: requirePeerAuth }, async (request, reply) => {
+    const config = app.config;
     const { id: trackId } = request.params as { id: string };
-    
+
     // Build the stream URL for local Navidrome
     const targetBase = config.navidromeUrl.replace(/\/+$/, "");
     const targetUrl = new URL(`${targetBase}/rest/stream`);

--- a/hub/test/proxy.test.ts
+++ b/hub/test/proxy.test.ts
@@ -23,6 +23,7 @@ import {
   canonicalSigningPayload,
   signRequest,
 } from "../src/federation/signing.js";
+import { FEDERATION_API_VERSION } from "../src/version.js";
 import type { KeyObject } from "node:crypto";
 import type { Config } from "../src/config.js";
 
@@ -102,6 +103,7 @@ function makePeerHeaders(opts: {
     "x-poutine-user": "test-user",
     "x-poutine-timestamp": ts,
     "x-poutine-signature": sig,
+    "poutine-api-version": String(FEDERATION_API_VERSION),
   };
 }
 


### PR DESCRIPTION
## Summary

#5: enforce a minimum compatible API version when peering — peers that omit the `poutine-api-version` header or advertise a version below the floor are rejected with 403.

## Changes

| Layer | File | Change |
|-------|------|--------|
| Backend | `hub/src/federation/peer-auth.ts` | Reject peer auth when header missing or version < 3. Store peer version in `instances` table. Respects `POUTINE_DISABLE_VERSION_CHECK` env var. |
| Backend | `hub/src/proxy/auth.ts` | Same version enforcement for `/proxy/*` routes |
| Backend | `hub/src/routes/federation.ts` | Apply peer auth middleware to `/stream/:id` (was unauthenticated) |
| Backend | `hub/src/routes/admin.ts` | Expose `apiVersion` on the instance info endpoint |
| Frontend | `frontend/src/lib/api.ts` | Add `appVersion` and `apiVersion` to `Peer` and `InstanceInfo` interfaces |
| Frontend | `frontend/src/pages/AdminPage.tsx` | Display federation API version in instance section; show peer app/api versions in peer list |
| Tests | `hub/test/proxy.test.ts` | Add `poutine-api-version` to `makePeerHeaders` helper |

## Notes

- Version floor is `FEDERATION_API_VERSION = 3` (from `hub/src/version.ts`).
- Set `POUTINE_DISABLE_VERSION_CHECK=true` to disable enforcement (e.g., during migrations).
- Part 1 (version info display) was handled in earlier merged work.