### PR TITLE
feat(share): share Album/Artist across federated peers (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Leave `PUBLIC_DIR` unset in dev so the hub does not attempt to serve static file
 
 See [docs/hub-internals.md#testing-notes](docs/hub-internals.md#testing-notes) for test patterns and gotchas.
 
+## Sharing albums and artists
+
+Each Album and Artist detail page has a **Share** button that copies a Poutine sharing ID to your clipboard. Paste that value into the Search box on a friend's hub to pull up the same entity there. The lookup works whenever both hubs sync the same underlying library (your Navidrome, your friend's, or any mutual peer); if the receiving hub doesn't sync an instance that has the item, search returns no results.
+
 ## Operations
 
 ### Updating a running instance

--- a/docs/hub-internals.md
+++ b/docs/hub-internals.md
@@ -115,6 +115,15 @@ Both defined in `hub/src/version.ts`. Protocol version also appears in `/library
 
 `USER_AGENT` is sent on every outgoing HTTP call from the hub: federation (`sign-request.ts`), Navidrome Subsonic (`adapters/subsonic.ts`), and peer health checks (`routes/admin.ts`).
 
+## Share IDs
+
+Users copy a "Share ID" for an album or artist from its detail page and paste it into Search on any peer hub that also syncs the same underlying library.
+
+- **Token**: bare `instance_*.remote_id` — the Navidrome hash (≈32 hex chars). No prefix, no encoding. Collision across unrelated Navidromes is negligible.
+- **Sender** (`pickAlbumShareId` / `pickArtistShareId` in `hub/src/routes/subsonic.ts`): picks one source row per entity; prefers `instance_id = 'local'`, else deterministic by instance id. Returned as `shareId` on `getAlbum` / `getArtist` responses.
+- **Receiver**: `/rest/search3` WHERE-clause joins through `unified_*_sources → instance_*` and matches `remote_id` alongside the existing name/UUID/MBID cases. If no hub the receiver syncs has the album, the search is empty (scenario D).
+- **No federation RPC involved.** Resolution is a local DB lookup against data the receiver already synced via `/proxy/*`.
+
 ## Frontend Subsonic client
 
 `frontend/src/lib/subsonic.ts`.

--- a/docs/opensubsonic.md
+++ b/docs/opensubsonic.md
@@ -78,7 +78,7 @@ All endpoints support both GET and POST, with and without the `.view` suffix (e.
 |-----------|-----------------|-------------------------------------|
 | `search`  | NOT IMPLEMENTED | Legacy v1 endpoint                  |
 | `search2` | NOT IMPLEMENTED |                                     |
-| `search3` | Implemented     | Name LIKE match; also matches internal IDs (with or without `ar`/`al`/`t` prefix) and MusicBrainz IDs on artists, albums, and songs |
+| `search3` | Implemented     | Name LIKE match; also matches internal IDs (with or without `ar`/`al`/`t` prefix), MusicBrainz IDs, and Poutine share IDs (upstream Navidrome `remote_id`; see [hub-internals.md](hub-internals.md#share-ids)) on artists, albums, and songs |
 
 ### Playlists
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -68,6 +68,8 @@ The `/federation/*` surface carries only peer identity/auth in v3. Content (audi
 
 Contract details (headers, signing payload, error codes): [federation-api.md](federation-api.md). `/proxy/*` auth modes: [hub-internals.md#proxy](hub-internals.md#proxy).
 
+Cross-hub share IDs for albums and artists are resolved entirely locally by each hub against its synced `instance_*` tables — no federation RPC. See [hub-internals.md#share-ids](hub-internals.md#share-ids).
+
 ## Data model
 
 Two tables per entity — one "raw" (per-instance), one "unified" (deduped across instances):

--- a/frontend/src/components/ShareIdButton.tsx
+++ b/frontend/src/components/ShareIdButton.tsx
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+export function ShareIdButton({ shareId, label = "Share" }: { shareId: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const onClick = async () => {
+    try {
+      await navigator.clipboard.writeText(shareId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      window.prompt("Copy this ID:", shareId);
+    }
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      title="Copy sharing ID — paste into Search on any peer hub that syncs the same library."
+      className="inline-flex items-center gap-2 px-4 py-1.5 bg-surface-hover hover:bg-surface text-text-primary rounded-full text-sm font-medium transition-colors cursor-pointer"
+    >
+      {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+      {copied ? "Copied!" : label}
+    </button>
+  );
+}

--- a/frontend/src/lib/subsonic.ts
+++ b/frontend/src/lib/subsonic.ts
@@ -15,6 +15,7 @@ export interface SubsonicArtist {
   name: string;
   albumCount: number;
   coverArt?: string;
+  shareId?: string;
 }
 
 export interface SubsonicAlbum {
@@ -26,6 +27,7 @@ export interface SubsonicAlbum {
   songCount: number;
   year?: number;
   genre?: string;
+  shareId?: string;
 }
 
 export interface SubsonicSong {
@@ -88,6 +90,7 @@ interface RawArtist {
   name: string;
   albumCount?: number;
   coverArt?: string;
+  shareId?: string;
 }
 
 interface RawAlbum {
@@ -100,6 +103,7 @@ interface RawAlbum {
   year?: number;
   genre?: string;
   song?: RawSong[];
+  shareId?: string;
 }
 
 interface RawSong {
@@ -143,6 +147,7 @@ function parseAlbum(raw: RawAlbum): SubsonicAlbum {
     songCount: raw.songCount ?? 0,
     year: raw.year,
     genre: raw.genre,
+    shareId: raw.shareId,
   };
 }
 
@@ -275,6 +280,7 @@ export async function getArtist(id: string): Promise<SubsonicArtistDetail> {
     name: raw.name,
     albumCount: raw.albumCount ?? raw.album?.length ?? 0,
     coverArt: raw.coverArt,
+    shareId: raw.shareId,
     album: (raw.album ?? []).map(parseAlbum),
   };
 }

--- a/frontend/src/pages/ArtistDetailPage.tsx
+++ b/frontend/src/pages/ArtistDetailPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getArtist, artUrl } from "@/lib/subsonic";
 import type { SubsonicAlbum } from "@/lib/subsonic";
 import { ChevronRight, Disc } from "lucide-react";
+import { ShareIdButton } from "@/components/ShareIdButton";
 
 function hashColor(name: string): string {
   let hash = 0;
@@ -71,6 +72,11 @@ export function ArtistDetailPage() {
             {artist.album.length}{" "}
             {artist.album.length === 1 ? "album" : "albums"}
           </p>
+          {artist.shareId && (
+            <div className="mt-3">
+              <ShareIdButton shareId={artist.shareId} />
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/ReleaseGroupPage.tsx
+++ b/frontend/src/pages/ReleaseGroupPage.tsx
@@ -6,6 +6,7 @@ import { usePlayer } from "@/stores/player";
 import { formatDuration } from "@/lib/format";
 import { Play, Plus, ChevronRight, Disc, ChevronDown, ChevronUp, FileAudio, Info } from "lucide-react";
 import { useState } from "react";
+import { ShareIdButton } from "@/components/ShareIdButton";
 
 function hashColor(name: string): string {
   let hash = 0;
@@ -88,6 +89,12 @@ export function ReleaseGroupPage() {
               <Play className="w-4 h-4 fill-current" />
               Play All
             </button>
+          )}
+
+          {album.shareId && (
+            <span className="mt-3 inline-flex mr-2">
+              <ShareIdButton shareId={album.shareId} />
+            </span>
           )}
 
           {/* Album metadata toggle */}

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -100,6 +100,42 @@ const BEST_SOURCE_INSTANCE_SUBQUERY = `
    ORDER BY COALESCE(ts.bitrate, 0) DESC LIMIT 1)
 `;
 
+// ── Share ID helpers ──────────────────────────────────────────────────────────
+// shareId is a raw `instance_*.remote_id` (typically a Navidrome 32-char hash).
+// Collision across unrelated Navidromes is negligible, so the bare id is a
+// usable cross-hub identifier — the receiving hub's search3 joins through
+// instance_albums / instance_artists and resolves it to its own unified id.
+// Prefer the 'local' source so that sharing an album from this hub's own
+// library emits an id the owner's Navidrome holds.
+function pickAlbumShareId(db: import("better-sqlite3").Database, rgId: string): string | null {
+  const row = db
+    .prepare(
+      `SELECT ia.remote_id
+       FROM unified_release_sources urs
+       JOIN unified_releases ur ON ur.id = urs.unified_release_id
+       JOIN instance_albums ia ON ia.id = urs.instance_album_id
+       WHERE ur.release_group_id = ?
+       ORDER BY (ia.instance_id = 'local') DESC, ia.instance_id, ia.remote_id
+       LIMIT 1`,
+    )
+    .get(rgId) as { remote_id: string } | undefined;
+  return row?.remote_id ?? null;
+}
+
+function pickArtistShareId(db: import("better-sqlite3").Database, artistId: string): string | null {
+  const row = db
+    .prepare(
+      `SELECT ia.remote_id
+       FROM unified_artist_sources uas
+       JOIN instance_artists ia ON ia.id = uas.instance_artist_id
+       WHERE uas.unified_artist_id = ?
+       ORDER BY (ia.instance_id = 'local') DESC, ia.instance_id, ia.remote_id
+       LIMIT 1`,
+    )
+    .get(artistId) as { remote_id: string } | undefined;
+  return row?.remote_id ?? null;
+}
+
 // ── Song shape builder ────────────────────────────────────────────────────────
 
 function buildSong(row: TrackRow) {
@@ -337,12 +373,15 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
       )
       .all(artistId) as ReleaseGroupRow[];
 
+    const shareId = pickArtistShareId(app.db, artist.id);
+
     sendSubsonicOk(reply, q, {
       artist: {
         id: encodeId("ar", artist.id),
         name: artist.name,
         albumCount: albums.length,
         coverArt: artist.image_url ?? undefined,
+        shareId: shareId ?? undefined,
         album: albums.map(buildAlbum),
       },
     });
@@ -575,6 +614,8 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
       0,
     );
 
+    const shareId = pickAlbumShareId(app.db, rg.id);
+
     sendSubsonicOk(reply, q, {
       album: {
         id: encodeId("al", rg.id),
@@ -586,6 +627,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
         duration: totalDuration,
         year: rg.year ?? undefined,
         genre: rg.genre ?? undefined,
+        shareId: shareId ?? undefined,
         song: tracks.map(buildSong),
       },
     });
@@ -664,6 +706,11 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
         WHERE ua.name_normalized LIKE ?
           OR ua.id = ? OR ua.id = ?
           OR ua.musicbrainz_id = ? OR ua.musicbrainz_id = ?
+          OR EXISTS (
+            SELECT 1 FROM unified_artist_sources uas
+            JOIN instance_artists iar ON iar.id = uas.instance_artist_id
+            WHERE uas.unified_artist_id = ua.id AND iar.remote_id = ?
+          )
         GROUP BY ua.id
         ORDER BY ua.name_normalized
         LIMIT ? OFFSET ?`,
@@ -674,6 +721,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
         artistIdCandidate,
         trimmed,
         artistIdCandidate,
+        trimmed,
         artistCount,
         artistOffset,
       ) as ArtistRow[];
@@ -690,6 +738,12 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
         WHERE urg.name_normalized LIKE ?
           OR urg.id = ? OR urg.id = ?
           OR urg.musicbrainz_id = ? OR urg.musicbrainz_id = ?
+          OR EXISTS (
+            SELECT 1 FROM unified_release_sources urs
+            JOIN unified_releases ur2 ON ur2.id = urs.unified_release_id
+            JOIN instance_albums ial ON ial.id = urs.instance_album_id
+            WHERE ur2.release_group_id = urg.id AND ial.remote_id = ?
+          )
         GROUP BY urg.id
         ORDER BY urg.name_normalized
         LIMIT ? OFFSET ?`,
@@ -700,6 +754,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
         albumIdCandidate,
         trimmed,
         albumIdCandidate,
+        trimmed,
         albumCount,
         albumOffset,
       ) as ReleaseGroupRow[];
@@ -726,6 +781,11 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
         WHERE ut.title_normalized LIKE ?
           OR ut.id = ? OR ut.id = ?
           OR ut.musicbrainz_id = ? OR ut.musicbrainz_id = ?
+          OR EXISTS (
+            SELECT 1 FROM track_sources ts2
+            JOIN instance_tracks it ON it.id = ts2.instance_track_id
+            WHERE ts2.unified_track_id = ut.id AND it.remote_id = ?
+          )
         ORDER BY ut.title_normalized
         LIMIT ? OFFSET ?`,
       )
@@ -735,6 +795,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
         songIdCandidate,
         trimmed,
         songIdCandidate,
+        trimmed,
         songCount,
         songOffset,
       ) as TrackRow[];

--- a/hub/test/subsonic-routes.test.ts
+++ b/hub/test/subsonic-routes.test.ts
@@ -448,4 +448,109 @@ describe("Subsonic routes — endpoints", () => {
     });
     expect(byMbid.json()["subsonic-response"].searchResult3.song).toHaveLength(1);
   });
+
+  // ── Share IDs ─────────────────────────────────────────────────────────────
+  // shareId surfaces the Navidrome remote_id of a source. search3 resolves
+  // it back to a unified entity via the join through instance_*.
+
+  async function seedShareFixture(app: FastifyInstance) {
+    const ownerId = (app.db.prepare("SELECT id FROM users LIMIT 1").get() as { id: string }).id;
+    app.db.prepare(
+      "INSERT OR IGNORE INTO instances (id, name, url, adapter_type, encrypted_credentials, owner_id) VALUES ('local', 'Local', 'http://nav/', 'subsonic', '', ?)",
+    ).run(ownerId);
+    app.db.prepare(
+      "INSERT OR IGNORE INTO instances (id, name, url, adapter_type, encrypted_credentials, owner_id) VALUES ('peer-x', 'Peer X', 'https://x/', 'subsonic', '', ?)",
+    ).run(ownerId);
+
+    // Artist: unified + two sources (local + peer-x). Local preferred.
+    app.db.prepare(
+      "INSERT INTO unified_artists (id, name, name_normalized) VALUES ('ua-1','Share Artist','share artist')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO instance_artists (id, instance_id, remote_id, name) VALUES ('local:LOC-AR-1','local','LOC-AR-1','Share Artist')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO instance_artists (id, instance_id, remote_id, name) VALUES ('peer-x:PX-AR-1','peer-x','PX-AR-1','Share Artist')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO unified_artist_sources (unified_artist_id, instance_artist_id, instance_id) VALUES ('ua-1','local:LOC-AR-1','local')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO unified_artist_sources (unified_artist_id, instance_artist_id, instance_id) VALUES ('ua-1','peer-x:PX-AR-1','peer-x')",
+    ).run();
+
+    // Album: unified release-group with one release + two source albums.
+    app.db.prepare(
+      "INSERT INTO unified_release_groups (id, name, name_normalized, artist_id) VALUES ('urg-1','Share Album','share album','ua-1')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO unified_releases (id, release_group_id, name) VALUES ('ur-1','urg-1','Share Album')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO instance_albums (id, instance_id, remote_id, name, artist_id, artist_name) VALUES ('local:LOC-AL-1','local','LOC-AL-1','Share Album','local:LOC-AR-1','Share Artist')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO instance_albums (id, instance_id, remote_id, name, artist_id, artist_name) VALUES ('peer-x:PX-AL-1','peer-x','PX-AL-1','Share Album','peer-x:PX-AR-1','Share Artist')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO unified_release_sources (unified_release_id, instance_album_id, instance_id) VALUES ('ur-1','local:LOC-AL-1','local')",
+    ).run();
+    app.db.prepare(
+      "INSERT INTO unified_release_sources (unified_release_id, instance_album_id, instance_id) VALUES ('ur-1','peer-x:PX-AL-1','peer-x')",
+    ).run();
+  }
+
+  it("getAlbum surfaces shareId preferring local source", async () => {
+    await seedShareFixture(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getAlbum?u=tester&p=secret&f=json&id=alurg-1",
+    });
+    const body = res.json();
+    expect(body["subsonic-response"].status).toBe("ok");
+    expect(body["subsonic-response"].album.shareId).toBe("LOC-AL-1");
+  });
+
+  it("getArtist surfaces shareId preferring local source", async () => {
+    await seedShareFixture(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getArtist?u=tester&p=secret&f=json&id=arua-1",
+    });
+    const body = res.json();
+    expect(body["subsonic-response"].status).toBe("ok");
+    expect(body["subsonic-response"].artist.shareId).toBe("LOC-AR-1");
+  });
+
+  it("search3 resolves album shareId from any source (peer)", async () => {
+    await seedShareFixture(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/search3?u=tester&p=secret&f=json&query=PX-AL-1",
+    });
+    const body = res.json();
+    expect(body["subsonic-response"].searchResult3.album).toHaveLength(1);
+    expect(body["subsonic-response"].searchResult3.album[0].name).toBe("Share Album");
+  });
+
+  it("search3 resolves artist shareId from any source (peer)", async () => {
+    await seedShareFixture(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/search3?u=tester&p=secret&f=json&query=PX-AR-1",
+    });
+    const body = res.json();
+    expect(body["subsonic-response"].searchResult3.artist).toHaveLength(1);
+  });
+
+  it("search3 with unknown remote_id returns no results", async () => {
+    await seedShareFixture(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/search3?u=tester&p=secret&f=json&query=NOPE-UNKNOWN-9",
+    });
+    const body = res.json();
+    expect(body["subsonic-response"].searchResult3.album ?? []).toHaveLength(0);
+    expect(body["subsonic-response"].searchResult3.artist ?? []).toHaveLength(0);
+  });
 });

--- a/test/federation/run.sh
+++ b/test/federation/run.sh
@@ -60,6 +60,11 @@ docker network create "$FED_NETWORK"
 
 # Pre-populate hub data volumes with the committed test keypairs so each hub
 # boots with a known identity (matching the public keys in peers-{a,b,c}.yaml).
+echo "==> Removing existing hub data volumes..."
+docker volume rm -f "${PROJECT_A}_hub-data"
+docker volume rm -f "${PROJECT_B}_hub-data"
+docker volume rm -f "${PROJECT_C}_hub-data"
+
 echo "==> Pre-populating hub data volumes with test keys..."
 docker volume create "${PROJECT_A}_hub-data"
 docker volume create "${PROJECT_B}_hub-data"
@@ -158,12 +163,12 @@ wait_http "http://localhost:3012/api/health" "hub-b" 120
 wait_http "http://localhost:3013/api/health" "hub-c" 120
 
 echo ""
-echo "==> Syncing hub-b local library (navidrome-b must scan first)..."
-login_and_sync 3012 "hub-b" 180 > /dev/null  # only care that it succeeds
-
-echo ""
 echo "==> Syncing hub-c local library (navidrome-c must scan first)..."
 login_and_sync 3013 "hub-c" 180 > /dev/null  # only care that it succeeds
+
+echo ""
+echo "==> Syncing hub-b local library (navidrome-b must scan first)..."
+login_and_sync 3012 "hub-b" 180 > /dev/null  # only care that it succeeds
 
 echo ""
 echo "==> Syncing hub-a (local + federated from hub-b and hub-c)..."

--- a/test/federation/run.sh
+++ b/test/federation/run.sh
@@ -270,6 +270,7 @@ ARTIST_ID=$(echo "$ALBUM_DETAIL" | python3 -c "
 import sys, json
 print(json.load(sys.stdin)['subsonic-response']['album']['artistId'])
 ")
+export OTHER_ALBUM_ID ARTIST_ID TRACK_ID_B
 echo ""
 echo "==> Testing search3 by album ID ($OTHER_ALBUM_ID)..."
 SEARCH_ALBUM=$(curl -sf \
@@ -282,7 +283,7 @@ match = [a for a in albums if a['id'] == target]
 assert match, f'No album with id {target} in search results: {[a[\"id\"] for a in albums]}'
 assert match[0]['name'] == 'Other Album', f'Expected Other Album, got {match[0][\"name\"]}'
 print(f'  search3 by album ID returned: {match[0][\"name\"]}')
-" OTHER_ALBUM_ID="$OTHER_ALBUM_ID"; then
+"; then
   echo "ERROR: search3 by album ID did not return the expected album" >&2
   echo "Response: $SEARCH_ALBUM" >&2
   exit 1
@@ -299,7 +300,7 @@ artists = json.load(sys.stdin)['subsonic-response'].get('searchResult3', {}).get
 match = [a for a in artists if a['id'] == target]
 assert match, f'No artist with id {target} in search results: {[a[\"id\"] for a in artists]}'
 print(f'  search3 by artist ID returned: {match[0][\"name\"]}')
-" ARTIST_ID="$ARTIST_ID"; then
+"; then
   echo "ERROR: search3 by artist ID did not return the expected artist" >&2
   echo "Response: $SEARCH_ARTIST" >&2
   exit 1
@@ -316,11 +317,85 @@ songs = json.load(sys.stdin)['subsonic-response'].get('searchResult3', {}).get('
 match = [s for s in songs if s['id'] == target]
 assert match, f'No song with id {target} in search results: {[s[\"id\"] for s in songs]}'
 print(f'  search3 by track ID returned: {match[0][\"title\"]}')
-" TRACK_ID_B="$TRACK_ID_B"; then
+"; then
   echo "ERROR: search3 by track ID did not return the expected song" >&2
   echo "Response: $SEARCH_TRACK" >&2
   exit 1
 fi
+
+# ── Share ID scenarios (issue #83) ────────────────────────────────────────────
+# Sender mints a shareId (a Navidrome remote_id) via getAlbum on its own hub;
+# receiver pastes into search3. Four scenarios exercised:
+#   A: album from hub-a's local Navidrome — B resolves via its sync of A.
+#   B: album from hub-b's Navidrome — A minted via sync of B; B resolves locally.
+#   C: album from hub-c's Navidrome (mutual peer) — B resolves via its own sync of C.
+#   D: a random remote_id that no hub knows — B returns empty results.
+
+echo ""
+echo "==> Share-ID scenarios (A/B/C/D)..."
+
+# Look up an album detail on a given hub, return its shareId.
+get_share_id() {
+  local port="$1" album_id="$2"
+  curl -sf "http://localhost:${port}/rest/getAlbum?u=${SUB_USER}&p=${SUB_PASS}&c=fed-test&v=1.14.0&f=json&id=${album_id}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['subsonic-response']['album'].get('shareId',''))"
+}
+
+assert_search_finds() {
+  local port="$1" query="$2" expected_name="$3" label="$4"
+  local resp
+  resp=$(curl -sf "http://localhost:${port}/rest/search3?u=${SUB_USER}&p=${SUB_PASS}&c=fed-test&v=1.14.0&f=json&query=${query}")
+  if ! echo "$resp" | EXPECTED="$expected_name" Q="$query" python3 -c "
+import sys, json, os
+name = os.environ['EXPECTED']
+albums = json.load(sys.stdin)['subsonic-response'].get('searchResult3', {}).get('album', [])
+match = [a for a in albums if a['name'] == name]
+assert match, f'Scenario ${label}: {name} not in results: {[a[\"name\"] for a in albums]}'
+print(f'  Scenario ${label}: hub on port ${port} resolved shareId {os.environ[\"Q\"]!r} -> {name}')
+"; then
+    echo "ERROR: scenario $label failed" >&2
+    echo "Response: $resp" >&2
+    exit 1
+  fi
+}
+
+assert_search_empty() {
+  local port="$1" query="$2" label="$3"
+  local resp
+  resp=$(curl -sf "http://localhost:${port}/rest/search3?u=${SUB_USER}&p=${SUB_PASS}&c=fed-test&v=1.14.0&f=json&query=${query}")
+  if ! echo "$resp" | python3 -c "
+import sys, json
+r = json.load(sys.stdin)['subsonic-response'].get('searchResult3', {})
+assert not r.get('album') and not r.get('artist') and not r.get('song'), f'Expected empty results, got {r}'
+print(f'  Scenario ${label}: empty results as expected')
+"; then
+    echo "ERROR: scenario $label expected empty results" >&2
+    echo "Response: $resp" >&2
+    exit 1
+  fi
+}
+
+# Resolve album IDs on hub-a for each scenario (A/B/C sourced albums).
+FIRST_ALBUM_ID=$(echo "$ALBUM_LIST" | python3 -c "
+import sys, json
+albums = json.load(sys.stdin)['subsonic-response']['albumList2']['album']
+print([a for a in albums if a['name'] == 'First Album'][0]['id'])
+")
+
+SHARE_A=$(get_share_id 3011 "$FIRST_ALBUM_ID")
+SHARE_B=$(get_share_id 3011 "$OTHER_ALBUM_ID")
+SHARE_C=$(get_share_id 3011 "$THIRD_ALBUM_ID")
+echo "  hub-a shareIds: A=${SHARE_A}  B=${SHARE_B}  C=${SHARE_C}"
+
+if [ -z "$SHARE_A" ] || [ -z "$SHARE_B" ] || [ -z "$SHARE_C" ]; then
+  echo "ERROR: getAlbum did not return shareId for all scenarios" >&2
+  exit 1
+fi
+
+assert_search_finds 3012 "$SHARE_A" "First Album" "A"
+assert_search_finds 3012 "$SHARE_B" "Other Album" "B"
+assert_search_finds 3012 "$SHARE_C" "Third Album" "C"
+assert_search_empty  3012 "ffffffffffffffffffffffffffffffff" "D"
 
 echo ""
 echo "==> All assertions passed!"


### PR DESCRIPTION
## Summary
- Share button on Album/Artist pages copies a Poutine sharing ID (Navidrome `remote_id`) to clipboard
- `/rest/search3` resolves the ID against artist/album/track sources — no federation RPC, no schema change
- `getAlbum` / `getArtist` expose `shareId`, preferring a `local` source

## Test plan
- [x] `pnpm test` + `pnpm typecheck`
- [x] `pnpm test:federation` — scenarios A (local), B (peer-owned), C (mutual peer), D (unreachable → empty)
- [x] Manual: copy on hub A, paste into Search on hub B, verify stream routes correctly

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)