### PR TITLE
fix: skip transcoding when source already fits the cap (refs #94)

### DIFF
--- a/frontend/src/lib/subsonic.ts
+++ b/frontend/src/lib/subsonic.ts
@@ -333,7 +333,9 @@ export interface EffectiveStream {
   bitRateIsCap: boolean; // true when we only know the ceiling (transcoded)
 }
 
-const LOSSY_FORMATS = new Set(["mp3", "opus", "aac", "ogg"]);
+// Mirrors the hub's stream-params.applyTranscodeRule so the player UI can
+// predict whether the server will transcode without waiting for the response.
+const LOSSY_SOURCE_FORMATS = new Set(["mp3", "opus", "aac", "ogg", "m4a"]);
 
 export function effectiveStream(
   source: { suffix?: string | null; bitRate?: number | null },
@@ -342,19 +344,22 @@ export function effectiveStream(
 ): EffectiveStream {
   const sourceFormat = source.suffix?.toLowerCase() ?? null;
   const sourceBitRate = source.bitRate ?? null;
-  if (sourceFormat && sourceFormat === format.toLowerCase()) {
-    // Same format → Navidrome passes through, capped at source bitrate.
-    const br = sourceBitRate != null ? Math.min(sourceBitRate, maxBitRate) : maxBitRate;
-    return { format, bitRate: br, bitRateIsCap: sourceBitRate == null };
+  if (!sourceFormat) {
+    return { format, bitRate: maxBitRate, bitRateIsCap: true };
   }
-  if (
-    sourceFormat && LOSSY_FORMATS.has(sourceFormat) &&
-    sourceBitRate != null && sourceBitRate <= maxBitRate
-  ) {
-    // Lossy source already under the cap → hub streams it raw.
-    return { format: sourceFormat, bitRate: sourceBitRate, bitRateIsCap: false };
+  const sameFormat = sourceFormat === format.toLowerCase();
+  const lossyPassthrough =
+    LOSSY_SOURCE_FORMATS.has(sourceFormat) &&
+    (sourceBitRate ?? Infinity) <= maxBitRate;
+  if (sameFormat || lossyPassthrough) {
+    // Server serves raw bytes.
+    return {
+      format: sourceFormat,
+      bitRate: sourceBitRate ?? maxBitRate,
+      bitRateIsCap: sourceBitRate == null,
+    };
   }
-  // Different format → transcoded. We only know the cap.
+  // Lossless source transcoded to target format (or source bitrate > cap).
   return { format, bitRate: maxBitRate, bitRateIsCap: true };
 }
 

--- a/hub/src/routes/stream-params.ts
+++ b/hub/src/routes/stream-params.ts
@@ -25,34 +25,43 @@ export function buildStreamParams(
   return p;
 }
 
-const LOSSY_FORMATS = new Set(["mp3", "opus", "aac", "ogg"]);
+// Lossy codecs — transcoding a lossy source to a different lossy codec
+// costs CPU and always degrades quality. If the source already fits under
+// the bitrate cap, drop the requested `format` so upstream Navidrome serves
+// the raw bytes. Lossless sources (flac, wav, alac) honor the request so
+// the client actually receives the compressed format it asked for.
+const LOSSY_FORMATS = new Set(["mp3", "opus", "aac", "ogg", "m4a"]);
 
 /**
- * Drop the `format` param when transcoding would be wasteful:
- * the source is already lossy and is already below the bitrate cap.
- * Keeps `maxBitRate` so Navidrome still enforces the ceiling if needed.
+ * Rewrite a set of Subsonic stream params in light of what the hub knows
+ * about the source file. The rule (issue #94):
  *
- * Lossless sources (flac/wav/alac) are always transcoded when the client
- * asks for a different format. Unknown source formats defer to the upstream.
+ *   - Source lossy AND source bitrate <= requested maxBitRate → drop
+ *     `format` so upstream serves raw bytes. `maxBitRate` is kept (it's a
+ *     ceiling; upstream will still transcode if the source exceeds it).
+ *   - Source lossless → keep `format` as-is (honor the request).
+ *   - Source format unknown → no change (defer to upstream).
+ *
+ * The hub applies this for every /rest/stream caller — SPA and 3rd-party
+ * Subsonic clients alike — because the calling hub is the only party that
+ * knows source format/bitrate for peer-routed tracks.
  */
-export function adjustStreamParamsForSource(
+export function applyTranscodeRule(
   params: URLSearchParams,
   source: { format: string | null; bitrate: number | null },
 ): URLSearchParams {
-  const reqFormat = params.get("format");
-  if (!reqFormat) return params;
-  const sf = source.format?.toLowerCase();
-  if (!sf) return params;
-  if (sf === reqFormat.toLowerCase()) {
-    params.delete("format");
-    return params;
+  const out = new URLSearchParams(params);
+  const reqFmt = out.get("format");
+  const srcFmt = source.format?.toLowerCase() ?? null;
+  if (!reqFmt || !srcFmt) return out;
+  if (reqFmt.toLowerCase() === srcFmt) {
+    // Already asking for the source format; let upstream passthrough.
+    out.delete("format");
+    return out;
   }
-  if (!LOSSY_FORMATS.has(sf)) return params;
-  const maxBr = params.get("maxBitRate");
-  const cap = maxBr ? parseInt(maxBr, 10) : null;
-  if (cap != null && source.bitrate != null && source.bitrate > cap) {
-    return params;
-  }
-  params.delete("format");
-  return params;
+  if (!LOSSY_FORMATS.has(srcFmt)) return out; // lossless — honor request
+  const cap = Number(out.get("maxBitRate")) || Infinity;
+  const srcBr = source.bitrate ?? Infinity;
+  if (srcBr <= cap) out.delete("format");
+  return out;
 }

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -12,7 +12,7 @@ import {
 } from "./subsonic-response.js";
 import { decodeCoverArtId } from "../library/cover-art.js";
 import { SubsonicClient } from "../adapters/subsonic.js";
-import { buildStreamParams, adjustStreamParamsForSource } from "./stream-params.js";
+import { applyTranscodeRule, buildStreamParams } from "./stream-params.js";
 import type { StreamTrackingService } from "../services/stream-tracking.js";
 
 // Extend Fastify app type for stream tracking
@@ -976,14 +976,14 @@ try {
   // At stream time we just look up THE source for this unified track.
   const best = app.db
     .prepare(
-      `SELECT ts.instance_id, it.remote_id, ts.format, ts.bitrate
+      `SELECT ts.instance_id, ts.format, ts.bitrate, it.remote_id
        FROM track_sources ts
        JOIN instance_tracks it ON it.id = ts.instance_track_id
        WHERE ts.unified_track_id = ? AND ts.preferred = 1
        LIMIT 1`,
     )
     .get(trackId) as
-    | { instance_id: string; remote_id: string; format: string | null; bitrate: number | null }
+    | { instance_id: string; format: string | null; bitrate: number | null; remote_id: string }
     | undefined;
 
   if (!best) {
@@ -991,7 +991,10 @@ try {
     return;
   }
 
-  const streamParams = adjustStreamParamsForSource(buildStreamParams(q), best);
+  const streamParams = applyTranscodeRule(buildStreamParams(q), {
+    format: best.format,
+    bitrate: best.bitrate,
+  });
   let response: Response;
   let bytesTransferred = 0;
 

--- a/hub/test/stream-params.test.ts
+++ b/hub/test/stream-params.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { applyTranscodeRule, buildStreamParams } from "../src/routes/stream-params.js";
+
+function run(q: Record<string, string>, src: { format: string | null; bitrate: number | null }) {
+  return Object.fromEntries(applyTranscodeRule(buildStreamParams(q), src));
+}
+
+describe("applyTranscodeRule", () => {
+  it("drops format when source is lossy and fits under the cap", () => {
+    // KMFDM "Light" scenario: MP3 128 with a 192 opus cap.
+    expect(run({ format: "opus", maxBitRate: "192" }, { format: "mp3", bitrate: 128 }))
+      .toEqual({ maxBitRate: "192" });
+  });
+
+  it("drops format when the requested format already matches the source", () => {
+    expect(run({ format: "opus", maxBitRate: "192" }, { format: "opus", bitrate: 128 }))
+      .toEqual({ maxBitRate: "192" });
+  });
+
+  it("keeps format when source is lossy but exceeds the cap", () => {
+    expect(run({ format: "opus", maxBitRate: "128" }, { format: "mp3", bitrate: 320 }))
+      .toEqual({ format: "opus", maxBitRate: "128" });
+  });
+
+  it("keeps format for lossless sources", () => {
+    expect(run({ format: "opus", maxBitRate: "192" }, { format: "flac", bitrate: 900 }))
+      .toEqual({ format: "opus", maxBitRate: "192" });
+  });
+
+  it("is a no-op when source format is unknown", () => {
+    expect(run({ format: "opus", maxBitRate: "192" }, { format: null, bitrate: null }))
+      .toEqual({ format: "opus", maxBitRate: "192" });
+  });
+
+  it("is a no-op when the request has no format (server chooses)", () => {
+    expect(run({ maxBitRate: "192" }, { format: "flac", bitrate: 900 }))
+      .toEqual({ maxBitRate: "192" });
+  });
+});


### PR DESCRIPTION
Sub-task of #77 (stacked on #90).

## Architecture

The Subsonic protocol has no way for a client to advertise a list of playable codecs — only a single \`format\` plus \`maxBitRate\`. That makes clients bad at this decision: the SPA hardcodes \`opus/192\` because it can't know per-track whether the source is already a format it can play. So the **server** decides, because the serving hub has every source's format and bitrate in \`track_sources\` and can apply the rule uniformly for SPA and 3rd-party clients.

Rule (in \`applyTranscodeRule\`, \`hub/src/routes/stream-params.ts\`):

- Source lossy (mp3/opus/aac/ogg/m4a) AND source bitrate ≤ requested \`maxBitRate\` → drop \`format\` so upstream serves raw.
- Requested format already matches source → drop \`format\` (passthrough).
- Lossless source (flac/wav/alac) → honor request.
- Unknown source format → no change.

Applied in \`handleStream\` before forwarding to local Navidrome OR the peer's \`/federation/stream\`. Peer-routed tracks work because the calling hub signs the final URL.

SPA's \`effectiveStream()\` mirrors the rule so \`PlayerBar\` predicts the correct label.

## Test plan

- [x] \`pnpm typecheck\` + \`pnpm test\` (245 passed, 6 new unit tests)
- [x] KMFDM "Light" (MP3 128) via \`other\` node → \`Content-Type: audio/mpeg\`
- [x] Same track via \`cd-rips\` peer node → \`Content-Type: audio/mpeg\`
- [x] Orbital FLAC → \`Content-Type: audio/ogg\` (unchanged)
- [ ] 3rd-party client sending \`format=mp3&maxBitRate=128\` against an MP3 128 source → raw passthrough

Base = \`fix/unify-stream-paths\`; retarget to \`main\` after #90 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)