### PR TITLE
fix(search): normalize query for case/unicode/punctuation

### DIFF
--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -11,6 +11,7 @@ import {
   decodeId,
 } from "./subsonic-response.js";
 import { decodeCoverArtId } from "../library/cover-art.js";
+import { normalizeName } from "../library/normalize.js";
 import { SubsonicClient } from "../adapters/subsonic.js";
 import { applyTranscodeRule, buildStreamParams } from "./stream-params.js";
 import type { StreamTrackingService } from "../services/stream-tracking.js";
@@ -688,7 +689,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
     const artistOffset = parseInt(q.artistOffset ?? "0", 10);
     const albumOffset = parseInt(q.albumOffset ?? "0", 10);
     const songOffset = parseInt(q.songOffset ?? "0", 10);
-    const like = `%${query}%`;
+    const like = `%${normalizeName(query)}%`;
 
     // ID lookup: allow pasting an internal ID (optionally prefixed ar/al/t)
     // or a MusicBrainz ID into the search box. Strip known prefixes so the

--- a/hub/test/subsonic-routes.test.ts
+++ b/hub/test/subsonic-routes.test.ts
@@ -543,6 +543,49 @@ describe("Subsonic routes — endpoints", () => {
     expect(body["subsonic-response"].searchResult3.artist).toHaveLength(1);
   });
 
+  it("search3 matches case-insensitively and across unicode/punctuation", async () => {
+    app.db
+      .prepare(
+        "INSERT INTO unified_artists (id, name, name_normalized) VALUES (?, ?, ?)",
+      )
+      .run("artist-bjork", "Björk", "bjork");
+    app.db
+      .prepare(
+        "INSERT INTO unified_artists (id, name, name_normalized) VALUES (?, ?, ?)",
+      )
+      .run("artist-acdc", "AC/DC", "acdc");
+
+    const mixedCase = await app.inject({
+      method: "GET",
+      url: "/rest/search3?u=tester&p=secret&f=json&query=BJORK",
+    });
+    expect(
+      mixedCase.json()["subsonic-response"].searchResult3.artist?.some(
+        (a: { id: string }) => a.id === "arartist-bjork",
+      ),
+    ).toBe(true);
+
+    const diacritic = await app.inject({
+      method: "GET",
+      url: `/rest/search3?u=tester&p=secret&f=json&query=${encodeURIComponent("Björk")}`,
+    });
+    expect(
+      diacritic.json()["subsonic-response"].searchResult3.artist?.some(
+        (a: { id: string }) => a.id === "arartist-bjork",
+      ),
+    ).toBe(true);
+
+    const punct = await app.inject({
+      method: "GET",
+      url: `/rest/search3?u=tester&p=secret&f=json&query=${encodeURIComponent("AC/DC")}`,
+    });
+    expect(
+      punct.json()["subsonic-response"].searchResult3.artist?.some(
+        (a: { id: string }) => a.id === "arartist-acdc",
+      ),
+    ).toBe(true);
+  });
+
   it("search3 with unknown remote_id returns no results", async () => {
     await seedShareFixture(app);
     const res = await app.inject({


### PR DESCRIPTION
## Summary
- `search3` compared `*_normalized` columns against the raw query, so diacritic and punctuation mismatches (e.g. `Björk`, `AC/DC`) returned no results. ASCII case appeared to work only because SQLite's default `LIKE` is case-insensitive for ASCII.
- Apply `normalizeName()` to the query before building the `%like%` pattern so it aligns with how the columns were indexed.

Closes #93

## Test plan
- [x] New test in `hub/test/subsonic-routes.test.ts` covers mixed case, diacritic, and punctuation queries
- [x] `pnpm test` (246 passed)
- [x] `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)