### PR TITLE
fix(db): fix musicfolder_id migration for SQLite compatibility

### DIFF
--- a/hub/src/db/client.ts
+++ b/hub/src/db/client.ts
@@ -19,6 +19,10 @@ function dropLegacyTables(db: Database.Database): void {
  * Apply additive column migrations for existing databases.
  * SQLite supports ADD COLUMN idempotently via PRAGMA table_info check.
  */
+function logMigration(msg: string): void {
+  console.log(`[DB Migration] ${msg}`);
+}
+
 /**
  * Migrate users.password_hash (Argon2id) → users.password_enc (AES-256-GCM).
  *
@@ -35,11 +39,13 @@ function migrateUserPasswords(db: Database.Database): void {
   const names = new Set(cols.map((c) => c.name));
 
   if (!names.has("password_enc")) {
+    logMigration("Adding password_enc column to users table");
     db.exec(
       "ALTER TABLE users ADD COLUMN password_enc TEXT NOT NULL DEFAULT ''",
     );
   }
   if (names.has("password_hash")) {
+    logMigration("Dropping password_hash column from users table");
     db.exec("ALTER TABLE users DROP COLUMN password_hash");
   }
 }
@@ -50,9 +56,11 @@ function ensureColumns(db: Database.Database): void {
     .all() as Array<{ name: string }>;
   const instanceColNames = new Set(instanceCols.map((c) => c.name));
   if (!instanceColNames.has("last_sync_ok")) {
+    logMigration("Adding last_sync_ok column to instances table");
     db.exec("ALTER TABLE instances ADD COLUMN last_sync_ok INTEGER");
   }
   if (!instanceColNames.has("last_sync_message")) {
+    logMigration("Adding last_sync_message column to instances table");
     db.exec("ALTER TABLE instances ADD COLUMN last_sync_message TEXT");
   }
   if (!instanceColNames.has("musicfolder_id")) {
@@ -60,7 +68,9 @@ function ensureColumns(db: Database.Database): void {
     // ordered by created_at so existing rows get deterministic IDs on upgrade.
     // SQLite forbids ADD COLUMN ... UNIQUE; add the column, backfill, then
     // enforce uniqueness via an index.
+    logMigration("Adding musicfolder_id column to instances table");
     db.exec("ALTER TABLE instances ADD COLUMN musicfolder_id INTEGER");
+    logMigration("Backfilling musicfolder_id values");
     db.exec(`
       UPDATE instances SET musicfolder_id = sub.rn FROM (
         SELECT id, ROW_NUMBER() OVER (ORDER BY created_at, id) AS rn FROM instances
@@ -76,12 +86,14 @@ function ensureColumns(db: Database.Database): void {
     .all() as Array<{ name: string }>;
   const trackSourceColNames = new Set(trackSourceCols.map((c) => c.name));
   if (!trackSourceColNames.has("preferred")) {
+    logMigration("Adding preferred column to track_sources table");
     db.exec(
       "ALTER TABLE track_sources ADD COLUMN preferred INTEGER NOT NULL DEFAULT 0",
     );
     // Backfill: pick a preferred source per unified track on existing DBs so
     // streaming keeps working before the next merge runs. Same rule merge.ts
     // applies after every sync.
+    logMigration("Backfilling preferred values in track_sources table");
     db.exec(`
       UPDATE track_sources SET preferred = 1 WHERE id IN (
         SELECT id FROM (
@@ -126,6 +138,7 @@ function migrateTrackSources(db: Database.Database): void {
   if (!names.has("source_kind") && !names.has("peer_id") && !names.has("remote_id")) {
     return; // already on new schema
   }
+  logMigration("Migrating track_sources table to new schema");
   db.exec(`
     DROP TABLE IF EXISTS track_sources;
     CREATE TABLE track_sources (
@@ -153,6 +166,7 @@ function migrateStreamOperations(db: Database.Database): void {
     .all() as Array<{ name: string }>;
   const names = new Set(cols.map((c) => c.name));
   if (cols.length > 0 && !names.has("kind")) {
+    logMigration("Migrating stream_operations table to new schema");
     db.exec("DROP TABLE IF EXISTS stream_operations");
     db.exec(`
       CREATE TABLE stream_operations (

--- a/hub/src/db/schema.sql
+++ b/hub/src/db/schema.sql
@@ -45,9 +45,6 @@ CREATE TABLE IF NOT EXISTS instances (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_instances_musicfolder_id
-  ON instances(musicfolder_id) WHERE musicfolder_id IS NOT NULL;
-
 -- ============================================================
 -- Raw Instance Data (per-instance mirror)
 -- ============================================================

--- a/hub/test/instances-migration.test.ts
+++ b/hub/test/instances-migration.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "path";
+import { createDatabase } from "../src/db/client.js";
+
+describe("instances.musicfolder_id migration (#123)", () => {
+  it("adds musicfolder_id column and backfills values for pre-#123 DBs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "poutine-mig-"));
+    const path = join(dir, "old.db");
+
+    // Build a pre-#123 DB by hand (without musicfolder_id column)
+    const old = new Database(path);
+    old.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA foreign_keys = ON;
+
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY,
+        username TEXT NOT NULL UNIQUE,
+        password_enc TEXT NOT NULL DEFAULT '',
+        is_admin INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE instances (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        url TEXT NOT NULL UNIQUE,
+        adapter_type TEXT NOT NULL DEFAULT 'subsonic',
+        encrypted_credentials TEXT NOT NULL DEFAULT '{}',
+        owner_id TEXT NOT NULL REFERENCES users(id),
+        status TEXT NOT NULL DEFAULT 'offline',
+        last_seen TEXT,
+        last_synced_at TEXT,
+        track_count INTEGER NOT NULL DEFAULT 0,
+        server_version TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      INSERT INTO users (id, username, password_enc, is_admin)
+        VALUES ('u1', 'admin', 'secret-key', 1);
+
+      INSERT INTO instances (id, name, url, encrypted_credentials, owner_id, created_at)
+        VALUES ('local', 'Local', 'http://localhost:4533', '{}', 'u1', '2024-01-01 00:00:00'),
+               ('peer-1', 'Peer One', 'http://peer1:4533', '{}', 'u1', '2024-01-02 00:00:00'),
+               ('peer-2', 'Peer Two', 'http://peer2:4533', '{}', 'u1', '2024-01-03 00:00:00');
+    `);
+    old.close();
+
+    // Run migration by creating the database
+    const db = createDatabase(path);
+
+    // Verify column was added
+    const cols = db
+      .prepare("PRAGMA table_info(instances)")
+      .all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    expect(names.has("musicfolder_id")).toBe(true);
+
+    // Verify values were backfilled (ordered by created_at)
+    const rows = db
+      .prepare("SELECT name, musicfolder_id FROM instances ORDER BY musicfolder_id")
+      .all() as Array<{ name: string; musicfolder_id: number }>;
+
+    expect(rows).toHaveLength(3);
+    expect(rows[0].name).toBe("Local");
+    expect(rows[0].musicfolder_id).toBe(1);
+    expect(rows[1].name).toBe("Peer One");
+    expect(rows[1].musicfolder_id).toBe(2);
+    expect(rows[2].name).toBe("Peer Two");
+    expect(rows[2].musicfolder_id).toBe(3);
+
+    // Verify unique index was created
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_instances_musicfolder_id'")
+      .all() as Array<{ name: string }>;
+    expect(indexes).toHaveLength(1);
+
+    db.close();
+    rmSync(dir, { recursive: true });
+  });
+
+  it("is a no-op on a fresh DB built from current schema.sql", () => {
+    const db = createDatabase(":memory:");
+    const cols = db
+      .prepare("PRAGMA table_info(instances)")
+      .all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    expect(names.has("musicfolder_id")).toBe(true);
+
+    // Verify the index exists
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_instances_musicfolder_id'")
+      .all() as Array<{ name: string }>;
+    expect(indexes).toHaveLength(1);
+
+    db.close();
+  });
+
+  it("handles empty instances table gracefully", () => {
+    const dir = mkdtempSync(join(tmpdir(), "poutine-mig-"));
+    const path = join(dir, "empty.db");
+
+    // Build a pre-#123 DB with empty instances table
+    const old = new Database(path);
+    old.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA foreign_keys = ON;
+
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY,
+        username TEXT NOT NULL UNIQUE,
+        password_enc TEXT NOT NULL DEFAULT '',
+        is_admin INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE instances (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        url TEXT NOT NULL UNIQUE,
+        adapter_type TEXT NOT NULL DEFAULT 'subsonic',
+        encrypted_credentials TEXT NOT NULL DEFAULT '{}',
+        owner_id TEXT NOT NULL REFERENCES users(id),
+        status TEXT NOT NULL DEFAULT 'offline',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      INSERT INTO users (id, username, password_enc, is_admin)
+        VALUES ('u1', 'admin', 'secret-key', 1);
+    `);
+    old.close();
+
+    // Run migration
+    const db = createDatabase(path);
+
+    // Verify column was added even with empty table
+    const cols = db
+      .prepare("PRAGMA table_info(instances)")
+      .all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    expect(names.has("musicfolder_id")).toBe(true);
+
+    // Verify table is still empty
+    const count = db.prepare("SELECT COUNT(*) as count FROM instances").get() as { count: number };
+    expect(count.count).toBe(0);
+
+    db.close();
+    rmSync(dir, { recursive: true });
+  });
+});


### PR DESCRIPTION
Fixes the 'no such column: musicfolder_id' error when upgrading from pre-0.4.4 versions.

## Root Cause

The `createDatabase()` function runs `db.exec(schema)` before `ensureColumns()`. On upgrade from pre-#123, the `CREATE TABLE IF NOT EXISTS instances` statement is a no-op (the table already exists), so `musicfolder_id` is never added. The very next statement in schema.sql — the partial unique index on that column — fails because the column doesn't exist yet, before the `ALTER TABLE` migration ever runs.

## Changes

- Move the `musicfolder_id` index creation from `schema.sql` to `ensureColumns()` after the `ALTER TABLE` adds the column
- Add logging to migration functions for better debugging
- Add comprehensive tests for the migration path (#123)

Note: The original `UPDATE ... FROM` backfill syntax was correct — SQLite has supported it since version 3.33 (Nov 2020).
