### PR TITLE
refactor(hub): centralize SQLite-to-ISO 8601 timestamp helper

### DIFF
--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -15,6 +15,7 @@ import { normalizeName } from "../library/normalize.js";
 import { SubsonicClient } from "../adapters/subsonic.js";
 import { applyTranscodeRule, buildStreamParams } from "./stream-params.js";
 import type { StreamTrackingService } from "../services/stream-tracking.js";
+import { sqliteToIso } from "../util/time.js";
 
 // Extend Fastify app type for stream tracking
 declare module "fastify" {
@@ -198,8 +199,7 @@ function annotateStarred<T extends { id: string }>(
   for (let i = 0; i < items.length; i++) {
     const ts = map.get(rawIds[i]);
     if (ts) {
-      const isoTs = ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
-      (items[i] as T & { starred?: string }).starred = isoTs;
+      (items[i] as T & { starred?: string }).starred = sqliteToIso(ts);
     }
   }
 }
@@ -1301,12 +1301,6 @@ try {
     return out;
   }
 
-  // SQLite's datetime('now') yields "YYYY-MM-DD HH:MM:SS" UTC; Subsonic clients
-  // expect ISO 8601 with 'T' separator and 'Z' suffix.
-  function toIsoStarred(ts: string): string {
-    return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
-  }
-
   route("/star", async (request, reply) => {
     const q = request.query as Record<string, string | string[] | undefined>;
     const userId = request.subsonicUser.id;
@@ -1401,15 +1395,15 @@ try {
         name: a.name,
         albumCount: a.albumCount,
         coverArt: a.image_url ?? undefined,
-        starred: toIsoStarred(a.starred_at),
+        starred: sqliteToIso(a.starred_at),
       })),
       album: albums.map((a) => ({
         ...buildAlbum(a),
-        starred: toIsoStarred(a.starred_at),
+        starred: sqliteToIso(a.starred_at),
       })),
       song: songs.map((s) => ({
         ...buildSong(s),
-        starred: toIsoStarred(s.starred_at),
+        starred: sqliteToIso(s.starred_at),
       })),
     };
   }

--- a/hub/src/util/time.ts
+++ b/hub/src/util/time.ts
@@ -1,0 +1,6 @@
+// SQLite's datetime('now') yields "YYYY-MM-DD HH:MM:SS" in UTC.
+// Subsonic clients (and most ISO 8601 consumers) expect "YYYY-MM-DDTHH:MM:SSZ".
+// Passes through values that already contain "T" so callers holding either form work.
+export function sqliteToIso(ts: string): string {
+  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
+}

--- a/hub/test/time.test.ts
+++ b/hub/test/time.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { sqliteToIso } from "../src/util/time.js";
+
+describe("sqliteToIso", () => {
+  it("converts SQLite datetime('now') output to ISO 8601 with T and Z", () => {
+    expect(sqliteToIso("2026-04-30 12:34:56")).toBe("2026-04-30T12:34:56Z");
+  });
+
+  it("passes through values that already contain a T separator", () => {
+    expect(sqliteToIso("2026-04-30T12:34:56Z")).toBe("2026-04-30T12:34:56Z");
+  });
+
+  it("passes through fractional ISO strings unchanged", () => {
+    expect(sqliteToIso("2026-04-30T12:34:56.789Z")).toBe("2026-04-30T12:34:56.789Z");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `sqliteToIso(ts)` to `hub/src/util/time.ts` with the already-ISO passthrough guard.
- Replace both inline conversions in `hub/src/routes/subsonic.ts` (`annotateStarred` + the local `toIsoStarred`) with the shared helper.
- Add unit tests covering SQLite form, ISO passthrough, and fractional ISO.

closes #129

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (332 passing, including new `time.test.ts`)
- [ ] No behavior change expected — verify starred timestamps still render in Subsonic clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)