### PR TITLE
fix(spa): toggle pause when play is clicked on the current track

### DIFF
--- a/frontend/src/pages/PlaylistsPage.test.tsx
+++ b/frontend/src/pages/PlaylistsPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PlaylistsPage } from "./PlaylistsPage";
+import { usePlayer } from "@/stores/player";
 
 vi.mock("@/lib/subsonic", async () => {
   const actual =
@@ -34,6 +35,7 @@ function renderAt(path: string) {
 beforeEach(() => {
   vi.mocked(getStarred2).mockReset();
   vi.mocked(getAlbum).mockReset();
+  usePlayer.setState({ queue: [], currentIndex: -1, isPlaying: false, currentTime: 0 });
 });
 
 describe("PlaylistsPage Favorites view (#104)", () => {
@@ -64,6 +66,36 @@ describe("PlaylistsPage Favorites view (#104)", () => {
       expect(screen.getByText("Idioteque")).toBeInTheDocument(),
     );
     expect(screen.getByText("1 track")).toBeInTheDocument();
+  });
+
+  it("shows always-visible play/pause toggle on the currently playing track (#99)", async () => {
+    const song = {
+      id: "ttrk-1",
+      title: "Idioteque",
+      album: "Kid A",
+      albumId: "alrg-1",
+      artist: "Radiohead",
+      artistId: "arar-1",
+      durationMs: 240000,
+      starred: "2026-04-28T00:00:00Z",
+    };
+    vi.mocked(getStarred2).mockResolvedValue({
+      artists: [],
+      albums: [],
+      songs: [song],
+    });
+    usePlayer.setState({ queue: [song], currentIndex: 0, isPlaying: true });
+
+    renderAt("/playlists/favorites");
+
+    await waitFor(() =>
+      expect(screen.getByText("Idioteque")).toBeInTheDocument(),
+    );
+    const btn = screen.getByTitle("Pause");
+    // Track number "1" must NOT render for the currently-playing row.
+    expect(btn.closest("td")?.textContent).toBe("");
+    // Both play and pause SVGs are present (CSS swaps on hover).
+    expect(btn.querySelectorAll("svg")).toHaveLength(2);
   });
 
   it("shows empty-state copy when no songs are starred", async () => {

--- a/frontend/src/pages/PlaylistsPage.tsx
+++ b/frontend/src/pages/PlaylistsPage.tsx
@@ -1,6 +1,6 @@
 import { Navigate, useParams, Link } from "react-router-dom";
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { Play, Plus, Star, ChevronRight } from "lucide-react";
+import { Play, Pause, Plus, Star, ChevronRight } from "lucide-react";
 import { getAlbum, getStarred2 } from "@/lib/subsonic";
 import type { SubsonicSong } from "@/lib/subsonic";
 import { usePlayer } from "@/stores/player";
@@ -25,7 +25,8 @@ export function PlaylistsPage() {
 }
 
 function FavoritesView() {
-  const { playTracks, addToQueue } = usePlayer();
+  const { playTracks, addToQueue, queue, currentIndex, isPlaying } = usePlayer();
+  const currentTrackId = currentIndex >= 0 ? queue[currentIndex]?.id : undefined;
   const { data, isLoading, error } = useQuery({
     queryKey: ["starred2"],
     queryFn: getStarred2,
@@ -133,6 +134,8 @@ function FavoritesView() {
                   }
                   onPlay={() => playTracks(songs, index)}
                   onAddToQueue={() => addToQueue(song)}
+                  isCurrent={currentTrackId === song.id}
+                  isPlaying={isPlaying}
                 />
               ))}
             </tbody>
@@ -149,24 +152,47 @@ function FavoriteRow({
   viaAlbumStar,
   onPlay,
   onAddToQueue,
+  isCurrent,
+  isPlaying,
 }: {
   song: SubsonicSong;
   index: number;
   viaAlbumStar: boolean;
   onPlay: () => void;
   onAddToQueue: () => void;
+  isCurrent: boolean;
+  isPlaying: boolean;
 }) {
   return (
     <tr className="group border-b border-border/50 last:border-0 hover:bg-surface-hover transition-colors">
       <td className="py-2.5 px-4 text-sm text-text-muted">
-        <span className="group-hover:hidden">{index + 1}</span>
-        <button
-          onClick={onPlay}
-          className="hidden group-hover:block text-text-primary hover:text-accent cursor-pointer"
-          title="Play"
-        >
-          <Play className="w-3.5 h-3.5 fill-current" />
-        </button>
+        {isCurrent ? (
+          <button
+            onClick={onPlay}
+            className="group/play block text-accent hover:text-accent cursor-pointer"
+            title={isPlaying ? "Pause" : "Play"}
+          >
+            {isPlaying ? (
+              <>
+                <Play className="w-3.5 h-3.5 fill-current group-hover/play:hidden" />
+                <Pause className="w-3.5 h-3.5 fill-current hidden group-hover/play:block" />
+              </>
+            ) : (
+              <Play className="w-3.5 h-3.5 fill-current" />
+            )}
+          </button>
+        ) : (
+          <>
+            <span className="group-hover:hidden">{index + 1}</span>
+            <button
+              onClick={onPlay}
+              className="hidden group-hover:block text-text-primary hover:text-accent cursor-pointer"
+              title="Play"
+            >
+              <Play className="w-3.5 h-3.5 fill-current" />
+            </button>
+          </>
+        )}
       </td>
       <td className="py-2.5 px-4">
         <p className="text-sm text-text-primary">{song.title}</p>

--- a/frontend/src/pages/ReleaseGroupPage.tsx
+++ b/frontend/src/pages/ReleaseGroupPage.tsx
@@ -4,7 +4,7 @@ import { getAlbum, artUrl } from "@/lib/subsonic";
 import type { SubsonicSong } from "@/lib/subsonic";
 import { usePlayer } from "@/stores/player";
 import { formatDuration } from "@/lib/format";
-import { Play, Plus, ChevronRight, Disc, ChevronDown, ChevronUp, FileAudio, Info } from "lucide-react";
+import { Play, Pause, Plus, ChevronRight, Disc, ChevronDown, ChevronUp, FileAudio, Info } from "lucide-react";
 import { useState } from "react";
 import { ShareIdButton } from "@/components/ShareIdButton";
 import { StarButton } from "@/components/StarButton";
@@ -21,7 +21,8 @@ function hashColor(name: string): string {
 
 export function ReleaseGroupPage() {
   const { id } = useParams<{ id: string }>();
-  const { playTracks, addToQueue } = usePlayer();
+  const { playTracks, addToQueue, queue, currentIndex, isPlaying } = usePlayer();
+  const currentTrackId = currentIndex >= 0 ? queue[currentIndex]?.id : undefined;
   const [expandedTrackId, setExpandedTrackId] = useState<string | null>(null);
   const [showAlbumMetadata, setShowAlbumMetadata] = useState(false);
 
@@ -167,6 +168,8 @@ export function ReleaseGroupPage() {
                 onAddToQueue={() => addToQueue(song)}
                 isExpanded={expandedTrackId === song.id}
                 onToggleMetadata={() => toggleTrackMetadata(song.id)}
+                isCurrent={currentTrackId === song.id}
+                isPlaying={isPlaying}
               />
             ))}
           </tbody>
@@ -193,6 +196,8 @@ function SongRow({
   onAddToQueue,
   isExpanded,
   onToggleMetadata,
+  isCurrent,
+  isPlaying,
 }: {
   song: SubsonicSong;
   index: number;
@@ -200,18 +205,40 @@ function SongRow({
   onAddToQueue: () => void;
   isExpanded: boolean;
   onToggleMetadata: () => void;
+  isCurrent: boolean;
+  isPlaying: boolean;
 }) {
   return (
     <>
       <tr className="group border-b border-border/50 last:border-0 hover:bg-surface-hover transition-colors">
         <td className="py-2.5 px-4 text-sm text-text-muted">
-          <span className="group-hover:hidden">{song.track ?? index + 1}</span>
-          <button
-            onClick={onPlay}
-            className="hidden group-hover:block text-text-primary hover:text-accent cursor-pointer"
-          >
-            <Play className="w-3.5 h-3.5 fill-current" />
-          </button>
+          {isCurrent ? (
+            <button
+              onClick={onPlay}
+              className="group/play block text-accent hover:text-accent cursor-pointer"
+              title={isPlaying ? "Pause" : "Play"}
+            >
+              {isPlaying ? (
+                <>
+                  <Play className="w-3.5 h-3.5 fill-current group-hover/play:hidden" />
+                  <Pause className="w-3.5 h-3.5 fill-current hidden group-hover/play:block" />
+                </>
+              ) : (
+                <Play className="w-3.5 h-3.5 fill-current" />
+              )}
+            </button>
+          ) : (
+            <>
+              <span className="group-hover:hidden">{song.track ?? index + 1}</span>
+              <button
+                onClick={onPlay}
+                className="hidden group-hover:block text-text-primary hover:text-accent cursor-pointer"
+                title="Play"
+              >
+                <Play className="w-3.5 h-3.5 fill-current" />
+              </button>
+            </>
+          )}
         </td>
         <td className="py-2.5 px-4">
           <p className="text-sm text-text-primary">{song.title}</p>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -5,7 +5,7 @@ import { search3 } from "@/lib/subsonic";
 import type { SubsonicSong } from "@/lib/subsonic";
 import { usePlayer } from "@/stores/player";
 import { formatDuration } from "@/lib/format";
-import { Search, Play, Disc, User, Music } from "lucide-react";
+import { Search, Play, Pause, Disc, User, Music } from "lucide-react";
 import { ErrorMessage } from "@/components/ui/ErrorMessage";
 
 function hashColor(name: string): string {
@@ -27,7 +27,8 @@ function initials(name: string): string {
 
 export function SearchPage() {
   const navigate = useNavigate();
-  const { playTrack } = usePlayer();
+  const { playTrack, queue, currentIndex, isPlaying } = usePlayer();
+  const currentTrackId = currentIndex >= 0 ? queue[currentIndex]?.id : undefined;
   const [input, setInput] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
@@ -165,7 +166,13 @@ export function SearchPage() {
               </h2>
               <div className="space-y-1">
                 {results.songs.slice(0, 10).map((song) => (
-                  <SongResult key={song.id} song={song} onPlay={() => playTrack(song)} />
+                  <SongResult
+                    key={song.id}
+                    song={song}
+                    onPlay={() => playTrack(song)}
+                    isCurrent={currentTrackId === song.id}
+                    isPlaying={isPlaying}
+                  />
                 ))}
               </div>
             </section>
@@ -176,14 +183,33 @@ export function SearchPage() {
   );
 }
 
-function SongResult({ song, onPlay }: { song: SubsonicSong; onPlay: () => void }) {
+function SongResult({
+  song,
+  onPlay,
+  isCurrent,
+  isPlaying,
+}: {
+  song: SubsonicSong;
+  onPlay: () => void;
+  isCurrent: boolean;
+  isPlaying: boolean;
+}) {
+  const showPauseHover = isCurrent && isPlaying;
   return (
     <div className="group flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-surface-hover transition-colors">
       <button
         onClick={onPlay}
-        className="w-10 h-10 rounded-md bg-surface flex items-center justify-center shrink-0 text-text-muted hover:text-accent transition-colors cursor-pointer"
+        className={`group/play w-10 h-10 rounded-md bg-surface flex items-center justify-center shrink-0 transition-colors cursor-pointer ${isCurrent ? "text-accent" : "text-text-muted hover:text-accent"}`}
+        title={showPauseHover ? "Pause" : "Play"}
       >
-        <Play className="w-4 h-4 fill-current" />
+        {showPauseHover ? (
+          <>
+            <Play className="w-4 h-4 fill-current group-hover/play:hidden" />
+            <Pause className="w-4 h-4 fill-current hidden group-hover/play:block" />
+          </>
+        ) : (
+          <Play className="w-4 h-4 fill-current" />
+        )}
       </button>
       <div className="min-w-0 flex-1">
         <p className="text-sm text-text-primary truncate">{song.title}</p>

--- a/frontend/src/stores/player.test.ts
+++ b/frontend/src/stores/player.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { usePlayer } from "./player";
+import type { SubsonicSong } from "@/lib/subsonic";
+
+const song = (id: string): SubsonicSong =>
+  ({ id, title: `t${id}`, durationMs: 1000 } as unknown as SubsonicSong);
+
+beforeEach(() => {
+  usePlayer.setState({ queue: [], currentIndex: -1, isPlaying: false, currentTime: 0 });
+});
+
+describe("player store play/pause toggle", () => {
+  it("playTrack on a new track starts playing", () => {
+    usePlayer.getState().playTrack(song("1"));
+    const s = usePlayer.getState();
+    expect(s.queue.map((q) => q.id)).toEqual(["1"]);
+    expect(s.currentIndex).toBe(0);
+    expect(s.isPlaying).toBe(true);
+  });
+
+  it("playTrack on the currently playing track pauses it", () => {
+    usePlayer.getState().playTrack(song("1"));
+    usePlayer.getState().playTrack(song("1"));
+    expect(usePlayer.getState().isPlaying).toBe(false);
+  });
+
+  it("playTrack on the current (paused) track resumes playback", () => {
+    usePlayer.getState().playTrack(song("1"));
+    usePlayer.setState({ isPlaying: false });
+    usePlayer.getState().playTrack(song("1"));
+    expect(usePlayer.getState().isPlaying).toBe(true);
+  });
+
+  it("playTrack on a different track replaces the queue", () => {
+    usePlayer.getState().playTrack(song("1"));
+    usePlayer.getState().playTrack(song("2"));
+    const s = usePlayer.getState();
+    expect(s.queue.map((q) => q.id)).toEqual(["2"]);
+    expect(s.isPlaying).toBe(true);
+  });
+
+  it("playTracks toggles pause when start track matches currently playing", () => {
+    const tracks = [song("1"), song("2"), song("3")];
+    usePlayer.getState().playTracks(tracks, 1);
+    expect(usePlayer.getState().currentIndex).toBe(1);
+    expect(usePlayer.getState().isPlaying).toBe(true);
+    usePlayer.getState().playTracks(tracks, 1);
+    expect(usePlayer.getState().isPlaying).toBe(false);
+  });
+
+  it("playTracks starting on a different index replaces queue", () => {
+    const tracks = [song("1"), song("2")];
+    usePlayer.getState().playTracks(tracks, 0);
+    usePlayer.getState().playTracks(tracks, 1);
+    expect(usePlayer.getState().currentIndex).toBe(1);
+    expect(usePlayer.getState().isPlaying).toBe(true);
+  });
+});

--- a/frontend/src/stores/player.ts
+++ b/frontend/src/stores/player.ts
@@ -49,10 +49,23 @@ export const usePlayer = create<PlayerState>((set, get) => ({
   },
 
   playTrack: (track) =>
-    set({ queue: [track], currentIndex: 0, isPlaying: true }),
+    set((state) => {
+      const current = state.queue[state.currentIndex];
+      if (current && current.id === track.id) {
+        return { isPlaying: !state.isPlaying };
+      }
+      return { queue: [track], currentIndex: 0, isPlaying: true };
+    }),
 
   playTracks: (tracks, startIndex = 0) =>
-    set({ queue: tracks, currentIndex: startIndex, isPlaying: true }),
+    set((state) => {
+      const requested = tracks[startIndex];
+      const current = state.queue[state.currentIndex];
+      if (requested && current && current.id === requested.id) {
+        return { isPlaying: !state.isPlaying };
+      }
+      return { queue: tracks, currentIndex: startIndex, isPlaying: true };
+    }),
 
   addToQueue: (track) =>
     set((state) => ({ queue: [...state.queue, track] })),


### PR DESCRIPTION
## Summary
- `playTrack` and `playTracks` in the player store now toggle `isPlaying` when the requested track matches the currently playing track instead of restarting the queue.
- Added unit tests covering pause-on-current, resume-on-current, replace-on-different-track, and the `playTracks` index variant.

closes #99

## Test plan
- [x] `pnpm --filter @poutine/frontend test`
- [x] `pnpm --filter @poutine/frontend typecheck`
- [ ] Manual: hover currently playing row in album / playlist / search, click play affordance — should pause; click again — should resume.