### PR TITLE
feat(images): fanart.tv as primary artist/album image source (#131)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,5 @@ Poutine: federated music player. Hub (Fastify + SQLite) bundles an internal Navi
 | `hub/src/db/schema.sql`              | Canonical DB schema — source of truth                            |
 | `docs/system-architecture.md`        | Current system architecture                                      |
 | `docs/frontend-testing.md`           | Vitest + RTL setup, patterns, gotchas                            |
+| `docs/fanarttv-integration.md`       | fanart.tv artist image / album cover source (primary, MBID-keyed) |
+| `docs/lastfm-integration.md`         | Last.fm fallback for artists without an MBID                     |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,12 @@ services:
       - POUTINE_PEERS_CONFIG=/app/config/peers.yaml
       - POUTINE_OWNER_USERNAME=${POUTINE_OWNER_USERNAME:?Set POUTINE_OWNER_USERNAME in .env}
       - POUTINE_OWNER_PASSWORD=${POUTINE_OWNER_PASSWORD:?Set POUTINE_OWNER_PASSWORD in .env}
+      # Optional overrides — empty in prod, used by test/local-cluster/.
+      - LASTFM_API_KEY=${LASTFM_API_KEY:-}
+      - FANARTTV_API_KEY=${FANARTTV_API_KEY:-}
+      - FANARTTV_CLIENT_KEY=${FANARTTV_CLIENT_KEY:-}
+      - FANARTTV_API_URL=${FANARTTV_API_URL:-}
+      - ART_CACHE_MAX_BYTES=${ART_CACHE_MAX_BYTES:-}
       # PUBLIC_DIR is baked into the image (hub/Dockerfile sets it to /app/hub/public).
       # Override here only if you want to mount a custom frontend build.
     volumes:

--- a/docs/fanarttv-integration.md
+++ b/docs/fanarttv-integration.md
@@ -1,0 +1,93 @@
+# fanart.tv Integration
+
+## Overview
+
+fanart.tv is the **primary** source for artist images and a fallback for album covers when the local library lacks one. Lookups are MusicBrainz-keyed: artists by artist MBID, albums by release-group MBID. Artists without an MBID are not queried.
+
+Poutine ships with a bundled project API key, so the integration is enabled by default. No setup is required.
+
+## Behavior
+
+| Scope   | Triggered when                                                            | Lookup key                |
+|---------|---------------------------------------------------------------------------|---------------------------|
+| Artist  | Artist has an MBID.                                                       | Artist MBID               |
+| Album   | Album has a release-group MBID **and** Navidrome has no `coverArt`.       | Release-group MBID        |
+
+For artists, fanart.tv wins over a Navidrome-provided cover when both exist. This is intentional — fanart.tv typically has higher-quality artist art (HD logos, banners, backgrounds) than what Navidrome surfaces.
+
+If fanart.tv has nothing for an artist (404 or empty image lists), Poutine falls back to Navidrome's `coverArt`. If that's also missing **and** the artist has no MBID and `LASTFM_API_KEY` is configured, Last.fm is consulted as a last resort. See [`lastfm-integration.md`](./lastfm-integration.md).
+
+Failure modes (network errors, non-OK statuses) are logged and treated as "no result" — they never fail a sync.
+
+## Image selection
+
+| Field                | Preference for…  | Notes                                          |
+|----------------------|------------------|------------------------------------------------|
+| `artistthumb`        | Artist image     | Square, ~1000×1000 — best for grid views.      |
+| `artistbackground`   | Artist fallback  | Wide background art if no thumb is available.  |
+| `albumcover`         | Album cover      | 1000×1000 release-group cover.                 |
+
+Within a list, the entry with the highest `likes` count wins.
+
+## Configuration
+
+| Env var                | Default                                        | Purpose                                                                                       |
+|------------------------|------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| `FANARTTV_API_KEY`     | `dd4c8d4d423b6bae65169cd5a6339d3f` (bundled)   | Project API key. Override only if you have your own.                                          |
+| `FANARTTV_CLIENT_KEY`  | _(unset)_                                       | Personal API key — drops the new-image delay from 7 days to 2.                                |
+| `FANARTTV_API_URL`     | `https://webservice.fanart.tv/v3.2`            | Base URL. Override for tests or self-hosted mirrors.                                          |
+
+To disable fanart.tv entirely, set `FANARTTV_API_KEY=""`.
+
+### Tier behavior
+
+| Tier               | Image freshness  |
+|--------------------|------------------|
+| Project (bundled)  | 7-day delay      |
+| Project + personal | 2-day delay      |
+| VIP membership     | Real-time        |
+
+Poutine caches results in `unified_artists.image_url` and `instance_albums.cover_art_id`, so the delay only affects newly-added artwork on the fanart.tv side.
+
+## Data storage
+
+- Artist images: stored as a URL in `unified_artists.image_url` and `instance_artists.image_url`.
+- Album covers: when supplied by fanart.tv, stored as a URL in `instance_albums.cover_art_id`. Subsonic stream/cover-art handlers detect the leading `https://` and serve it directly rather than reverse-proxying Navidrome.
+
+## API reference
+
+### `FanartTvClient`
+
+Located at `hub/src/services/fanarttv.ts`.
+
+| Method                                     | Description                                                                |
+|--------------------------------------------|----------------------------------------------------------------------------|
+| `isEnabled()`                              | True if a project key is configured.                                       |
+| `getArtist(mbid)`                          | Fetches `/music/{mbid}`. Returns `null` on 404 or any error.               |
+| `getAlbum(releaseGroupMbid)`               | Fetches `/music/albums/{rg-mbid}`. Returns `null` on 404 or any error.     |
+| `static bestArtistImage(resp)`             | Picks `artistthumb` → `artistbackground`. Highest-liked entry wins.        |
+| `static bestAlbumCover(resp, rgMbid)`      | Picks the best `albumcover` for the given release-group MBID.              |
+
+## Troubleshooting
+
+### Verify the integration is enabled
+
+Server log line on startup:
+
+```
+fanart.tv integration enabled — using bundled Poutine project key
+```
+
+(Or `using overridden project key` if `FANARTTV_API_KEY` is set.)
+
+### Test the API directly
+
+```bash
+curl "https://webservice.fanart.tv/v3.2/music/a74b1b7f-71a5-4011-9441-d0b5e4122711?api_key=$FANARTTV_API_KEY"
+```
+
+### An artist has no image
+
+- Confirm the artist has an MBID in `unified_artists.musicbrainz_id`. Without one, fanart.tv is skipped.
+- Verify fanart.tv has artwork for that MBID via the curl test above.
+- Newly-added artwork is delayed 7 days for project-key access. Set `FANARTTV_CLIENT_KEY` to drop that to 2 days.

--- a/docs/fanarttv-integration.md
+++ b/docs/fanarttv-integration.md
@@ -51,8 +51,18 @@ Poutine caches results in `unified_artists.image_url` and `instance_albums.cover
 
 ## Data storage
 
-- Artist images: stored as a URL in `unified_artists.image_url` and `instance_artists.image_url`.
-- Album covers: when supplied by fanart.tv, stored as a URL in `instance_albums.cover_art_id`. Subsonic stream/cover-art handlers detect the leading `https://` and serve it directly rather than reverse-proxying Navidrome.
+- Artist images: stored as a URL in `unified_artists.image_url` and `instance_artists.image_url`. Frontend `artUrl()` short-circuits absolute URLs and the browser fetches them directly, so artist images do not go through `/rest/getCoverArt`.
+- Album covers: when supplied by fanart.tv, stored as a URL in `instance_albums.cover_art_id`. After merge, `unified_release_groups.image_url` holds the encoded `instanceId:https://...` form; `decodeCoverArtId` splits at the first colon so the URL survives. The Subsonic `getCoverArt` handler detects the leading `https://` and fetches it directly rather than reverse-proxying Navidrome.
+
+### SSRF allowlist
+
+External URLs reached via `/rest/getCoverArt` are validated by `hub/src/routes/external-art.ts` before fetching:
+
+- https only (http rejected).
+- Hostname must be `fanart.tv` or end in `.fanart.tv`.
+- All other hosts → 400 "Disallowed external art URL".
+
+This prevents a malicious peer from federating a `cover_art_id` pointing at intranet endpoints. If new external image sources are added later, extend the allowlist there — not at the call site.
 
 ## API reference
 

--- a/docs/hub-internals.md
+++ b/docs/hub-internals.md
@@ -37,6 +37,7 @@ Root `package.json` scripts fan out to both: `dev`, `build`, `test`, `lint`, `ty
 | `FANARTTV_API_KEY`           | no       | bundled Poutine project key  | fanart.tv project API key. Primary source for MBID-keyed artist images and an album-cover fallback. Set to `""` to disable. See [fanarttv-integration.md](fanarttv-integration.md) |
 | `FANARTTV_CLIENT_KEY`        | no       | —                            | Optional fanart.tv personal `client_key` — drops the new-image delay from 7 days to 2 |
 | `FANARTTV_API_URL`           | no       | `https://webservice.fanart.tv/v3.2` | Override fanart.tv base URL (tests, mirrors)                  |
+| `ART_CACHE_MAX_BYTES`        | no       | `100 MB` (104857600)         | Hard cap for the on-disk image cache. Applied on every boot, overrides the persisted `art_cache_max_bytes` setting. Test clusters use `10485760` (10 MB) |
 
 `hub/src/config.ts` is the authoritative list.
 
@@ -83,7 +84,7 @@ Returns `401` if all three methods fail.
 
 - Served via `GET /rest/getCoverArt?id={encodedId}`. Disk cache with LRU eviction.
 - Cache metadata: `art_cache` table. Files: `{dataDir}/cache/art/`.
-- Max size configurable via `GET/PUT /admin/cache`; clear via `DELETE /admin/cache`. Stored in `settings` table, default 10 MB.
+- Max size configurable via `GET/PUT /admin/cache`; clear via `DELETE /admin/cache`. Stored in `settings` table, default 100 MB. `ART_CACHE_MAX_BYTES` env var, when set, overrides the stored value on every boot.
 - **Encoded IDs:** `{instanceId}:{coverArtId}`. Subsonic art IDs are instance-local, so the hub must know which upstream to query. Helpers in `hub/src/library/cover-art.ts`.
 - The Subsonic `coverArt` field IS the encoded ID — `buildAlbum`/`buildSong` set it to `row.image_url`, which already stores the encoded form. Pass directly to `artUrl()` on the frontend; no further encoding.
 

--- a/docs/hub-internals.md
+++ b/docs/hub-internals.md
@@ -33,6 +33,10 @@ Root `package.json` scripts fan out to both: `dev`, `build`, `test`, `lint`, `ty
 | `POUTINE_PASSWORD_KEY_PATH`  | no       | `./data/poutine_password_key`| AES-256 password encryption key (32 bytes, base64, mode 0600). Auto-generated if absent. **Back this up — losing it makes every stored password unrecoverable.** |
 | `POUTINE_PEERS_CONFIG`       | no       | `./config/peers.yaml`        | Peer registry file                                              |
 | `PUBLIC_DIR`                 | no       | —                            | Compiled frontend `dist/`. Baked into Docker image. Unset in dev |
+| `LASTFM_API_KEY`             | no       | —                            | Last.fm API key. Fallback artist-image source for artists **without** an MBID. See [lastfm-integration.md](lastfm-integration.md) |
+| `FANARTTV_API_KEY`           | no       | bundled Poutine project key  | fanart.tv project API key. Primary source for MBID-keyed artist images and an album-cover fallback. Set to `""` to disable. See [fanarttv-integration.md](fanarttv-integration.md) |
+| `FANARTTV_CLIENT_KEY`        | no       | —                            | Optional fanart.tv personal `client_key` — drops the new-image delay from 7 days to 2 |
+| `FANARTTV_API_URL`           | no       | `https://webservice.fanart.tv/v3.2` | Override fanart.tv base URL (tests, mirrors)                  |
 
 `hub/src/config.ts` is the authoritative list.
 

--- a/docs/lastfm-integration.md
+++ b/docs/lastfm-integration.md
@@ -1,8 +1,21 @@
-# Last.fm Artist Image Integration
+# Artist & Album Image Integration
 
 ## Overview
 
-This feature enables automatic fetching of artist images from Last.fm during library sync and on-demand via the `/rest/getArtistInfo2` endpoint.
+Poutine fetches artist images from two sources, picked per-artist by what's available:
+
+| Source         | Used when                                                | Lookup key                |
+|----------------|----------------------------------------------------------|---------------------------|
+| **fanart.tv**  | Artist has a MusicBrainz ID. Always enabled (bundled key). | Artist MBID               |
+| **Last.fm**    | Artist has **no** MBID **and** `LASTFM_API_KEY` is set.  | Artist name               |
+
+Album covers come from Navidrome. fanart.tv is also consulted as a cover fallback when an album has a release-group MBID but Navidrome has no cover (expected to be rare).
+
+See [`fanarttv-integration.md`](./fanarttv-integration.md) for the fanart.tv-specific details.
+
+## Last.fm overview
+
+Last.fm is the fallback path for artists missing an MBID. It is also exposed on-demand via `/rest/getArtistInfo2`.
 
 ## Setup
 
@@ -49,13 +62,13 @@ Last.fm integration disabled — set LASTFM_API_KEY env var to enable
 
 ### During Sync
 
-When you trigger a sync via `/admin/sync`:
+For each artist, in order:
 
-1. For each artist, poutine first tries to get the image from Navidrome's `getArtist()` response
-2. If no image is found and Last.fm is enabled:
-   - Fetches artist info from Last.fm using the artist name
-   - Falls back to MusicBrainz ID if available (more accurate)
-   - Caches the best available image URL in `unified_artists.image_url`
+1. If the artist has an **MBID**, fanart.tv is queried first. Result wins over Navidrome's cover.
+2. Otherwise the Navidrome-provided `coverArt` is used.
+3. If still no image and the artist has **no MBID** and `LASTFM_API_KEY` is set, Last.fm is queried by artist name.
+
+Artists with an MBID never trigger Last.fm.
 
 ### On-Demand via API
 

--- a/example.env
+++ b/example.env
@@ -33,3 +33,17 @@ POUTINE_INSTANCE_ID=blacktop
 # change the password through the admin UI, not here.
 POUTINE_OWNER_USERNAME=nic
 POUTINE_OWNER_PASSWORD=local
+
+# --- Artist & album image sources --------------------------------------------
+
+# fanart.tv is the primary source for artist images (when the artist has an
+# MBID) and a fallback for album covers (album with a release-group MBID and
+# no Navidrome cover). A bundled Poutine project key is used by default, so
+# leave these unset unless you want to override.
+#
+# FANARTTV_API_KEY=                       # override bundled project key
+# FANARTTV_CLIENT_KEY=                    # personal key — 2-day vs 7-day delay
+# FANARTTV_API_URL=https://webservice.fanart.tv/v3.2
+
+# Last.fm is the fallback for artists WITHOUT an MBID. Optional.
+# LASTFM_API_KEY=

--- a/hub/src/config.ts
+++ b/hub/src/config.ts
@@ -24,6 +24,12 @@ export interface Config {
   staticDir: string | undefined;
   // Optional: Last.fm API key for artist images and metadata
   lastFmApiKey: string | undefined;
+  // fanart.tv: project API key (defaults to bundled Poutine key) + optional
+  // personal client_key for faster image updates. Base URL is overridable for
+  // tests.
+  fanartTvProjectKey: string;
+  fanartTvPersonalKey: string | undefined;
+  fanartTvBaseUrl: string;
 }
 
 function requireInProd(name: string, value: string | undefined): string {
@@ -82,5 +88,10 @@ export function loadConfig(): Config {
     ),
     staticDir: process.env.PUBLIC_DIR || undefined,
     lastFmApiKey: process.env.LASTFM_API_KEY || undefined,
+    fanartTvProjectKey:
+      process.env.FANARTTV_API_KEY || "dd4c8d4d423b6bae65169cd5a6339d3f",
+    fanartTvPersonalKey: process.env.FANARTTV_CLIENT_KEY || undefined,
+    fanartTvBaseUrl:
+      process.env.FANARTTV_API_URL || "https://webservice.fanart.tv/v3.2",
   };
 }

--- a/hub/src/config.ts
+++ b/hub/src/config.ts
@@ -30,6 +30,10 @@ export interface Config {
   fanartTvProjectKey: string;
   fanartTvPersonalKey: string | undefined;
   fanartTvBaseUrl: string;
+  // Optional: overrides the persisted art_cache_max_bytes setting on every
+  // boot. Useful for test clusters where you want a tiny cap regardless of
+  // what's stored in the DB.
+  artCacheMaxBytes: number | undefined;
 }
 
 function requireInProd(name: string, value: string | undefined): string {
@@ -93,5 +97,8 @@ export function loadConfig(): Config {
     fanartTvPersonalKey: process.env.FANARTTV_CLIENT_KEY || undefined,
     fanartTvBaseUrl:
       process.env.FANARTTV_API_URL || "https://webservice.fanart.tv/v3.2",
+    artCacheMaxBytes: process.env.ART_CACHE_MAX_BYTES
+      ? parseInt(process.env.ART_CACHE_MAX_BYTES, 10)
+      : undefined,
   };
 }

--- a/hub/src/library/sync-instance.ts
+++ b/hub/src/library/sync-instance.ts
@@ -14,6 +14,8 @@ import type Database from "better-sqlite3";
 import { USER_AGENT } from "../version.js";
 import type { SyncResult } from "./sync.js";
 import type { LastFmClient } from "../services/lastfm.js";
+import { FanartTvClient } from "../services/fanarttv.js";
+import type { FanartTvClient as FanartTvClientType } from "../services/fanarttv.js";
 
 // ── Subsonic JSON envelope types (minimal) ────────────────────────────────────
 
@@ -177,7 +179,12 @@ export async function readNavidromeViaProxy(
   db: Database.Database,
   instanceId: string,
   proxyFetch: ProxyFetch,
-  config: { concurrency?: number; log?: SyncLogger; lastFmClient?: LastFmClient | null } = {},
+  config: {
+    concurrency?: number;
+    log?: SyncLogger;
+    lastFmClient?: LastFmClient | null;
+    fanartTvClient?: FanartTvClientType | null;
+  } = {},
 ): Promise<SyncResult> {
   const concurrency = config.concurrency ?? 3;
   const log = config.log ?? noopLogger;
@@ -308,21 +315,40 @@ export async function readNavidromeViaProxy(
           const detail = data.artist as NavidromeArtistDetail;
           const artistCompositeId = `${instanceId}:${artist.id}`;
 
-          // Get image from Navidrome first
-          let artistImageUrl: string | null = detail.coverArt ?? artist.coverArt ?? null;
+          const artistMbid =
+            detail.musicBrainzId ?? artist.musicBrainzId ?? null;
+          let artistImageUrl: string | null = null;
 
-          // If no image and Last.fm is enabled, try to fetch from Last.fm
-          if (!artistImageUrl && config.lastFmClient?.isEnabled()) {
+          // Primary: fanart.tv when an MBID is available.
+          if (artistMbid && config.fanartTvClient?.isEnabled()) {
+            try {
+              const resp = await config.fanartTvClient.getArtist(artistMbid);
+              artistImageUrl = FanartTvClient.bestArtistImage(resp);
+            } catch {
+              // fanart.tv lookup failed — fall through to other sources.
+            }
+          }
+
+          // Otherwise use whatever Navidrome provided.
+          if (!artistImageUrl) {
+            artistImageUrl = detail.coverArt ?? artist.coverArt ?? null;
+          }
+
+          // Last.fm fallback only when there is no MBID (per #131 spec) and a
+          // Last.fm API key is configured. Artists with an MBID rely on
+          // fanart.tv plus the Navidrome-provided image.
+          if (
+            !artistImageUrl &&
+            !artistMbid &&
+            config.lastFmClient?.isEnabled()
+          ) {
             try {
               const lastFmInfo = await config.lastFmClient.getArtistInfo(
                 detail.name ?? artist.name,
-                detail.musicBrainzId ?? artist.musicBrainzId ?? undefined
               );
               if (lastFmInfo) {
                 const bestImage = config.lastFmClient.getBestImage(lastFmInfo);
-                if (bestImage) {
-                  artistImageUrl = bestImage;
-                }
+                if (bestImage) artistImageUrl = bestImage;
               }
             } catch {
               // Last.fm fetch failed, keep existing image URL (or null)
@@ -334,7 +360,7 @@ export async function readNavidromeViaProxy(
             instanceId,
             artist.id,
             detail.name ?? artist.name,
-            detail.musicBrainzId ?? artist.musicBrainzId ?? null,
+            artistMbid,
             detail.albumCount ?? artist.albumCount ?? 0,
             artistImageUrl,
           );
@@ -364,6 +390,30 @@ export async function readNavidromeViaProxy(
           const albumCompositeId = `${instanceId}:${album.id}`;
           const durationMs = detail.duration ? detail.duration * 1000 : null;
 
+          const releaseGroupMbid =
+            ((detail as unknown as Record<string, unknown>).releaseGroupMbid as
+              | string
+              | undefined) ?? null;
+          const albumMbid = detail.musicBrainzId ?? album.musicBrainzId ?? null;
+          let coverArtId: string | null =
+            detail.coverArt ?? album.coverArt ?? null;
+
+          // Album cover fallback: if Navidrome has no cover but the album has
+          // a release-group MBID, try fanart.tv. Expected to be rare.
+          if (
+            !coverArtId &&
+            releaseGroupMbid &&
+            config.fanartTvClient?.isEnabled()
+          ) {
+            try {
+              const resp = await config.fanartTvClient.getAlbum(releaseGroupMbid);
+              const url = FanartTvClient.bestAlbumCover(resp, releaseGroupMbid);
+              if (url) coverArtId = url;
+            } catch {
+              // fanart.tv lookup failed — leave coverArtId null.
+            }
+          }
+
           upsertAlbum.run(
             albumCompositeId,
             instanceId,
@@ -373,11 +423,11 @@ export async function readNavidromeViaProxy(
             detail.artist ?? album.artist ?? "",
             detail.year ?? album.year ?? null,
             detail.genre ?? album.genre ?? null,
-            detail.musicBrainzId ?? album.musicBrainzId ?? null,
-            (detail as unknown as Record<string, unknown>).releaseGroupMbid as string ?? null,
+            albumMbid,
+            releaseGroupMbid,
             detail.songCount ?? album.songCount ?? 0,
             durationMs,
-            detail.coverArt ?? album.coverArt ?? null,
+            coverArtId,
             detail.created ?? album.created ?? null,
           );
           seenAlbumRemoteIds.add(album.id);

--- a/hub/src/library/sync-local.ts
+++ b/hub/src/library/sync-local.ts
@@ -11,11 +11,13 @@ import type { Config } from "../config.js";
 import { readNavidromeViaProxy, createLocalProxyFetch } from "./sync-instance.js";
 import type { SyncResult } from "./sync.js";
 import type { LastFmClient } from "../services/lastfm.js";
+import type { FanartTvClient } from "../services/fanarttv.js";
 
 export async function syncLocal(
   db: Database.Database,
   config: Config,
   lastFmClient?: LastFmClient | null,
+  fanartTvClient?: FanartTvClient | null,
 ): Promise<SyncResult> {
   const proxyFetch = createLocalProxyFetch({
     proxyBaseUrl: config.navidromeUrl,
@@ -26,6 +28,7 @@ export async function syncLocal(
   return readNavidromeViaProxy(db, "local", proxyFetch, {
     concurrency: config.instanceConcurrency,
     lastFmClient: lastFmClient ?? null,
+    fanartTvClient: fanartTvClient ?? null,
     log: {
       info: (msg) => console.log(msg),
       error: (msg) => console.error(msg),

--- a/hub/src/library/sync-peer.ts
+++ b/hub/src/library/sync-peer.ts
@@ -16,6 +16,7 @@ import { readNavidromeViaProxy } from "./sync-instance.js";
 import type { SyncLogger } from "./sync-instance.js";
 import type { SyncResult } from "./sync.js";
 import type { LastFmClient } from "../services/lastfm.js";
+import type { FanartTvClient } from "../services/fanarttv.js";
 
 export type FederationFetcher = ReturnType<typeof createFederationFetcher>;
 
@@ -25,6 +26,7 @@ export async function syncPeer(
   federatedFetch: FederationFetcher,
   asUser: string,
   lastFmClient: LastFmClient | null,
+  fanartTvClient: FanartTvClient | null,
   opts: { concurrency?: number; log?: SyncLogger } = {},
 ): Promise<SyncResult> {
   // Build a ProxyFetch for this peer's /proxy/* endpoint.
@@ -50,5 +52,6 @@ export async function syncPeer(
     concurrency: opts.concurrency,
     log,
     lastFmClient,
+    fanartTvClient,
   });
 }

--- a/hub/src/library/sync.ts
+++ b/hub/src/library/sync.ts
@@ -9,6 +9,7 @@ import { SyncOperationService } from "../services/sync-operations.js";
 import { mergeLibraries } from "./merge.js";
 import { seedSyntheticInstances } from "./seed-instances.js";
 import type { LastFmClient } from "../services/lastfm.js";
+import type { FanartTvClient } from "../services/fanarttv.js";
 
 /** Minimal instance descriptor used by sync callers. */
 export interface Instance {
@@ -46,6 +47,7 @@ export async function syncAll(
   syncOpService?: SyncOperationService,
   operationType: SyncOperationType = "manual",
   lastFmClient?: LastFmClient | null,
+  fanartTvClient?: FanartTvClient | null,
 ): Promise<{ local: SyncResult; peers: SyncResult[] }> {
   const operationId = syncOpService?.start(operationType, "local") || null;
   let localResult: SyncResult;
@@ -54,7 +56,7 @@ export async function syncAll(
   seedSyntheticInstances(db, config, peerRegistry);
 
   try {
-    localResult = await syncLocal(db, config, lastFmClient ?? null);
+    localResult = await syncLocal(db, config, lastFmClient ?? null, fanartTvClient ?? null);
   } catch (err) {
     if (operationId) {
       syncOpService!.fail(operationId, [`Local sync failed: ${String(err)}`]);
@@ -70,7 +72,7 @@ export async function syncAll(
     }
 
     try {
-      const peerResult = await syncPeer(db, peer, federatedFetch, ownerUsername, lastFmClient ?? null);
+      const peerResult = await syncPeer(db, peer, federatedFetch, ownerUsername, lastFmClient ?? null, fanartTvClient ?? null);
       peers.push(peerResult);
       if (peerOperationId && syncOpService) {
         syncOpService.complete(peerOperationId, 0, 0, peerResult.trackCount, peerResult.errors);

--- a/hub/src/routes/admin.ts
+++ b/hub/src/routes/admin.ts
@@ -420,6 +420,7 @@ export const adminRoutes: FastifyPluginAsync = async (app) => {
       app.syncOpService,
       "manual",
       app.lastFmClient,
+      app.fanartTvClient,
     );
   });
 

--- a/hub/src/routes/external-art.ts
+++ b/hub/src/routes/external-art.ts
@@ -1,0 +1,33 @@
+/**
+ * External cover-art URL allowlist.
+ *
+ * `instance_albums.cover_art_id` may hold a full https URL when the cover
+ * came from fanart.tv. The Subsonic getCoverArt route fetches such URLs
+ * directly, so the value must be constrained to prevent SSRF — peers
+ * federate `cover_art_id` values, and an attacker-controlled peer could
+ * otherwise point us at intranet endpoints.
+ */
+
+const ALLOWED_HOSTNAMES: readonly string[] = [
+  "fanart.tv",
+  "assets.fanart.tv",
+];
+
+const ALLOWED_SUFFIXES: readonly string[] = [".fanart.tv"];
+
+export function isAllowedExternalArtUrl(value: string): boolean {
+  if (!value.startsWith("https://")) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "https:") return false;
+
+  const host = parsed.hostname.toLowerCase();
+  if (ALLOWED_HOSTNAMES.includes(host)) return true;
+  return ALLOWED_SUFFIXES.some((sfx) => host.endsWith(sfx));
+}

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -976,7 +976,17 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
 
     let response: Response;
 
-    if (instanceId !== "local") {
+    // External URL (e.g. fanart.tv album cover stored when Navidrome had none).
+    // The decoded coverArtId is the full https:// URL — fetch it directly
+    // instead of routing through Navidrome or a peer proxy.
+    if (coverArtId.startsWith("https://") || coverArtId.startsWith("http://")) {
+      try {
+        response = await fetch(coverArtId);
+      } catch {
+        sendBinaryError(reply, 502, "Failed to fetch external art");
+        return;
+      }
+    } else if (instanceId !== "local") {
       // Peer art routing via /proxy/rest/getCoverArt — Ed25519-signed request to the peer's proxy.
       // The signing path must include the /proxy prefix (as seen by the peer's Fastify router).
       const peer = app.peerRegistry.peers.get(instanceId);

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -1,6 +1,5 @@
 import type { FastifyPluginAsync, RouteHandlerMethod } from "fastify";
 import { Readable } from "node:stream";
-import { readFileSync } from "node:fs";
 import type { Peer } from "../federation/peers.js";
 import { requireSubsonicAuth, requireSubsonicAuthBinary } from "../auth/subsonic-auth.js";
 import {
@@ -963,14 +962,13 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
     // Check cache first (covers both local and peer art)
     const cached = app.artCache.get(cacheKey);
     if (cached) {
-      const data = readFileSync(cached.filePath);
       reply.raw.writeHead(200, {
         "content-type": cached.contentType,
-        "content-length": String(data.length),
+        "content-length": String(cached.data.length),
         "cache-control": "public, max-age=2592000",
         "x-cache": "HIT",
       });
-      reply.raw.end(data);
+      reply.raw.end(cached.data);
       return;
     }
 

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -10,6 +10,7 @@ import {
   decodeId,
 } from "./subsonic-response.js";
 import { decodeCoverArtId } from "../library/cover-art.js";
+import { isAllowedExternalArtUrl } from "./external-art.js";
 import { normalizeName } from "../library/normalize.js";
 import { SubsonicClient } from "../adapters/subsonic.js";
 import { applyTranscodeRule, buildStreamParams } from "./stream-params.js";
@@ -982,8 +983,14 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
 
     // External URL (e.g. fanart.tv album cover stored when Navidrome had none).
     // The decoded coverArtId is the full https:// URL — fetch it directly
-    // instead of routing through Navidrome or a peer proxy.
-    if (coverArtId.startsWith("https://") || coverArtId.startsWith("http://")) {
+    // instead of routing through Navidrome or a peer proxy. Restricted to a
+    // fanart.tv hostname allowlist; peer-supplied URLs to other hosts are
+    // rejected to prevent SSRF.
+    if (coverArtId.startsWith("http://") || coverArtId.startsWith("https://")) {
+      if (!isAllowedExternalArtUrl(coverArtId)) {
+        sendBinaryError(reply, 400, "Disallowed external art URL");
+        return;
+      }
       try {
         response = await fetch(coverArtId);
       } catch {

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -959,9 +959,11 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
 
     const cacheKey = size ? `${id}:${size}` : id;
 
-    // Check cache first (covers both local and peer art)
+    // Check cache first (covers both local and peer art). Skip a hit if the
+    // cached entry is not a real image — old Navidrome "missing cover" XML
+    // envelopes may have been cached before the upstream-validation fix.
     const cached = app.artCache.get(cacheKey);
-    if (cached) {
+    if (cached && cached.contentType.startsWith("image/") && cached.data.length > 0) {
       reply.raw.writeHead(200, {
         "content-type": cached.contentType,
         "content-length": String(cached.data.length),
@@ -970,6 +972,10 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
       });
       reply.raw.end(cached.data);
       return;
+    }
+    if (cached) {
+      // Poisoned entry — drop it and re-fetch.
+      app.artCache.delete(cacheKey);
     }
 
     let response: Response;
@@ -1044,6 +1050,15 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
     }
     const buffer = Buffer.concat(chunks);
     const contentType = response.headers.get("content-type") || "image/jpeg";
+
+    // Navidrome answers a missing cover with HTTP 200 + a Subsonic XML/JSON
+    // error envelope (Content-Type: text/xml or application/json), not an
+    // image. Don't cache or serve those — let the client treat it as 404 so
+    // a future re-sync can supply a real cover (e.g. via fanart.tv).
+    if (buffer.length === 0 || !contentType.startsWith("image/")) {
+      sendBinaryError(reply, 404, "Art not found");
+      return;
+    }
 
     app.artCache.put(cacheKey, buffer, contentType);
 

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -23,6 +23,7 @@ import { AutoSyncService } from "./services/auto-sync.js";
 import { SyncOperationService } from "./services/sync-operations.js";
 import { StreamTrackingService } from "./services/stream-tracking.js";
 import { LastFmClient } from "./services/lastfm.js";
+import { FanartTvClient } from "./services/fanarttv.js";
 import type { Config } from "./config.js";
 import type Database from "better-sqlite3";
 import type { KeyObject } from "node:crypto";
@@ -43,6 +44,7 @@ declare module "fastify" {
   syncOpService: SyncOperationService;
   streamTracking: StreamTrackingService;
   lastFmClient: LastFmClient | null;
+  fanartTvClient: FanartTvClient | null;
 }
 }
 
@@ -133,6 +135,27 @@ export async function buildApp(configOverrides?: Partial<Config>) {
   }
   app.decorate("lastFmClient", lastFmClient);
 
+  // fanart.tv client — primary source for artist images when MBID is known,
+  // and an album-cover fallback when an album has an MBID but no cover.
+  // Always enabled; the bundled Poutine project key is used by default.
+  const fanartTvClient = config.fanartTvProjectKey
+    ? new FanartTvClient({
+        projectKey: config.fanartTvProjectKey,
+        personalKey: config.fanartTvPersonalKey,
+        baseUrl: config.fanartTvBaseUrl,
+      })
+    : null;
+  if (fanartTvClient) {
+    const usingDefault =
+      config.fanartTvProjectKey === "dd4c8d4d423b6bae65169cd5a6339d3f";
+    app.log.info(
+      `fanart.tv integration enabled — ${usingDefault ? "using bundled Poutine project key" : "using overridden project key"}${config.fanartTvPersonalKey ? " + personal client_key" : ""}`,
+    );
+  } else {
+    app.log.info("fanart.tv integration disabled — no project key configured");
+  }
+  app.decorate("fanartTvClient", fanartTvClient);
+
   // Password encryption key (AES-256-GCM, on disk beside the federation key)
   const passwordKey = loadOrCreatePasswordKey(config.poutinePasswordKeyPath);
   app.decorate("passwordKey", passwordKey);
@@ -209,7 +232,7 @@ export async function buildApp(configOverrides?: Partial<Config>) {
   const autoSync = new AutoSyncService(db, config, {
     info: (msg) => app.log.info(msg),
     error: (msg) => app.log.error(msg),
-}, syncOpService, lastFmClient);
+}, syncOpService, lastFmClient, fanartTvClient);
 
   // SIGHUP handler to reload peer registry without restart
   const sighupHandler = () => {

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -147,6 +147,7 @@ export async function buildApp(configOverrides?: Partial<Config>) {
         projectKey: config.fanartTvProjectKey,
         personalKey: config.fanartTvPersonalKey,
         baseUrl: config.fanartTvBaseUrl,
+        log: app.log,
       })
     : null;
   if (fanartTvClient) {

--- a/hub/src/server.ts
+++ b/hub/src/server.ts
@@ -122,6 +122,10 @@ export async function buildApp(configOverrides?: Partial<Config>) {
   const { dirname, join } = await import("node:path");
   const cacheDir = join(dirname(config.databasePath), "cache", "art");
   const artCache = new ArtCache(db, cacheDir);
+  if (config.artCacheMaxBytes !== undefined && Number.isFinite(config.artCacheMaxBytes) && config.artCacheMaxBytes > 0) {
+    artCache.setMaxBytes(config.artCacheMaxBytes);
+    app.log.info(`Art cache cap set from ART_CACHE_MAX_BYTES env: ${config.artCacheMaxBytes} bytes`);
+  }
   app.decorate("artCache", artCache);
 
   // Last.fm client — optional, only if API key is configured

--- a/hub/src/services/art-cache.ts
+++ b/hub/src/services/art-cache.ts
@@ -1,12 +1,12 @@
 import type Database from "better-sqlite3";
-import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync, readdirSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 
 const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 
 export interface CacheEntry {
-  filePath: string;
+  data: Buffer;
   contentType: string;
 }
 
@@ -40,18 +40,24 @@ export class ArtCache {
     if (!row) return null;
 
     const filePath = this.filePathForKey(key);
-    if (!existsSync(filePath)) {
-      // DB row exists but file is missing — clean up
+    let data: Buffer;
+    try {
+      // Read synchronously inside the method to avoid a TOCTOU race with
+      // evict() — concurrent puts can run eviction between an existsSync()
+      // check and a later readFileSync() in the caller, causing ENOENT.
+      data = readFileSync(filePath);
+    } catch {
+      // File missing or unreadable — clean up the DB row and miss the cache.
       this.db.prepare("DELETE FROM art_cache WHERE id = ?").run(key);
       return null;
     }
 
-    // Update last_accessed
+    // Update last_accessed (best-effort; harmless if it loses a race)
     this.db
       .prepare("UPDATE art_cache SET last_accessed = datetime('now') WHERE id = ?")
       .run(key);
 
-    return { filePath, contentType: row.content_type };
+    return { data, contentType: row.content_type };
   }
 
   put(key: string, data: Buffer, contentType: string): void {
@@ -70,19 +76,33 @@ export class ArtCache {
       )
       .run(key, contentType, data.length);
 
-    this.evict();
+    this.evict(key);
   }
 
-  evict(): void {
+  /**
+   * Evict least-recently-accessed entries until the cache is back under the
+   * configured size cap. `protectKey`, when supplied, is excluded from the
+   * candidate set — `last_accessed` only has 1-second precision, so the entry
+   * we just wrote can otherwise share a timestamp with older rows and get
+   * evicted out from under the calling request.
+   */
+  evict(protectKey?: string): void {
     const maxBytes = this.getMaxBytes();
     const currentBytes = this.getCurrentBytes();
 
     if (currentBytes <= maxBytes) return;
 
-    // Get entries ordered by least recently accessed
-    const entries = this.db
-      .prepare("SELECT id, size FROM art_cache ORDER BY last_accessed ASC")
-      .all() as Array<{ id: string; size: number }>;
+    // Get entries ordered by least recently accessed, excluding the just-
+    // written key if any.
+    const entries = (protectKey
+      ? this.db
+          .prepare(
+            "SELECT id, size FROM art_cache WHERE id != ? ORDER BY last_accessed ASC",
+          )
+          .all(protectKey)
+      : this.db
+          .prepare("SELECT id, size FROM art_cache ORDER BY last_accessed ASC")
+          .all()) as Array<{ id: string; size: number }>;
 
     let freed = 0;
     const target = currentBytes - maxBytes;

--- a/hub/src/services/art-cache.ts
+++ b/hub/src/services/art-cache.ts
@@ -148,6 +148,16 @@ export class ArtCache {
     this.evict();
   }
 
+  /** Remove a single entry by key. Used to drop poisoned cache entries. */
+  delete(key: string): void {
+    try {
+      unlinkSync(this.filePathForKey(key));
+    } catch {
+      // File may already be gone
+    }
+    this.db.prepare("DELETE FROM art_cache WHERE id = ?").run(key);
+  }
+
   clear(): void {
     const entries = this.db
       .prepare("SELECT id FROM art_cache")

--- a/hub/src/services/art-cache.ts
+++ b/hub/src/services/art-cache.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 
-const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+const DEFAULT_MAX_BYTES = 100 * 1024 * 1024; // 100 MB
 
 export interface CacheEntry {
   data: Buffer;

--- a/hub/src/services/auto-sync.ts
+++ b/hub/src/services/auto-sync.ts
@@ -5,6 +5,7 @@ import { syncLocal } from "../library/sync-local.js";
 import { mergeLibraries } from "../library/merge.js";
 import { SyncOperationService } from "./sync-operations.js";
 import { LastFmClient } from "./lastfm.js";
+import { FanartTvClient } from "./fanarttv.js";
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -18,6 +19,7 @@ export class AutoSyncService {
     private readonly log: { info: (msg: string) => void; error: (msg: string) => void },
     private readonly syncOpService?: SyncOperationService,
     private readonly lastFmClient?: LastFmClient | null,
+    private readonly fanartTvClient?: FanartTvClient | null,
   ) {}
 
   start(): void {
@@ -72,7 +74,12 @@ export class AutoSyncService {
       // a "running" sync row appearing every 30s for no-op poll ticks.
       const operationId = this.syncOpService?.start("auto", "local") || null;
       try {
-        const result = await syncLocal(this.db, this.config, this.lastFmClient ?? null);
+        const result = await syncLocal(
+          this.db,
+          this.config,
+          this.lastFmClient ?? null,
+          this.fanartTvClient ?? null,
+        );
         mergeLibraries(this.db);
         this.log.info(
           `AutoSync complete: ${result.artistCount} artists, ${result.albumCount} albums, ${result.trackCount} tracks`,

--- a/hub/src/services/fanarttv.ts
+++ b/hub/src/services/fanarttv.ts
@@ -1,0 +1,129 @@
+/**
+ * fanart.tv API client.
+ *
+ * Lookups are MBID-only. Artists key on artist MBID; albums key on release-group MBID.
+ *
+ * Tier behaviour:
+ * - Project key only: 7-day delay on newly added images (fine for Poutine).
+ * - Project + personal client_key: 2-day delay.
+ *
+ * 404 means "no artwork on file" — treated as a normal empty result, not an error.
+ */
+import { USER_AGENT } from "../version.js";
+
+const DEFAULT_BASE_URL = "https://webservice.fanart.tv/v3.2";
+/** Poutine's bundled project key. Override with FANARTTV_API_KEY. */
+export const POUTINE_FANARTTV_PROJECT_KEY = "dd4c8d4d423b6bae65169cd5a6339d3f";
+
+/** Single image entry as returned by fanart.tv v3.2 (artist or album scope). */
+export interface FanartTvImage {
+  id: string;
+  url: string;
+  lang?: string;
+  likes?: string;
+  width?: string;
+  height?: string;
+}
+
+export interface FanartTvAlbum {
+  albumcover?: FanartTvImage[];
+  cdart?: FanartTvImage[];
+}
+
+export interface FanartTvArtistResponse {
+  name?: string;
+  mbid_id?: string;
+  artistbackground?: FanartTvImage[];
+  artistthumb?: FanartTvImage[];
+  hdmusiclogo?: FanartTvImage[];
+  musiclogo?: FanartTvImage[];
+  musicbanner?: FanartTvImage[];
+  albums?: Record<string, FanartTvAlbum>;
+}
+
+export class FanartTvClient {
+  private readonly projectKey: string;
+  private readonly personalKey: string | undefined;
+  private readonly baseUrl: string;
+
+  constructor(opts: { projectKey: string; personalKey?: string; baseUrl?: string }) {
+    this.projectKey = opts.projectKey;
+    this.personalKey = opts.personalKey;
+    this.baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  }
+
+  isEnabled(): boolean {
+    return this.projectKey.length > 0;
+  }
+
+  private buildUrl(path: string): string {
+    const params = new URLSearchParams({ api_key: this.projectKey });
+    if (this.personalKey) params.set("client_key", this.personalKey);
+    return `${this.baseUrl}${path}?${params.toString()}`;
+  }
+
+  private async fetchJson<T>(path: string): Promise<T | null> {
+    if (!this.isEnabled()) return null;
+    try {
+      const res = await fetch(this.buildUrl(path), {
+        headers: { "user-agent": USER_AGENT },
+      });
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        console.error(`fanart.tv API error: ${res.status} ${res.statusText}`);
+        return null;
+      }
+      return (await res.json()) as T;
+    } catch (err) {
+      console.error(`fanart.tv API request failed: ${err}`);
+      return null;
+    }
+  }
+
+  /** Look up an artist by MusicBrainz Artist ID. */
+  getArtist(mbid: string): Promise<FanartTvArtistResponse | null> {
+    return this.fetchJson<FanartTvArtistResponse>(`/music/${encodeURIComponent(mbid)}`);
+  }
+
+  /**
+   * Look up an album by MusicBrainz Release-Group ID.
+   *
+   * fanart.tv's album endpoint also lives under /music/ — albums are nested in
+   * the artist response keyed by release-group MBID. The dedicated /music/albums/
+   * path returns the same album subtree without needing the artist MBID.
+   */
+  getAlbum(releaseGroupMbid: string): Promise<FanartTvArtistResponse | null> {
+    return this.fetchJson<FanartTvArtistResponse>(
+      `/music/albums/${encodeURIComponent(releaseGroupMbid)}`,
+    );
+  }
+
+  /** Best artist image — prefer thumb, then background. Returns null if none. */
+  static bestArtistImage(resp: FanartTvArtistResponse | null): string | null {
+    if (!resp) return null;
+    return (
+      pickFirstUrl(resp.artistthumb) ??
+      pickFirstUrl(resp.artistbackground) ??
+      null
+    );
+  }
+
+  /** Best album cover for a given release-group MBID, looked up inside the response. */
+  static bestAlbumCover(
+    resp: FanartTvArtistResponse | null,
+    releaseGroupMbid: string,
+  ): string | null {
+    const album = resp?.albums?.[releaseGroupMbid];
+    if (!album) return null;
+    return pickFirstUrl(album.albumcover) ?? null;
+  }
+}
+
+function pickFirstUrl(images: FanartTvImage[] | undefined): string | null {
+  if (!images || images.length === 0) return null;
+  // Prefer entries with the most likes, then first.
+  const sorted = [...images].sort(
+    (a, b) => parseInt(b.likes ?? "0", 10) - parseInt(a.likes ?? "0", 10),
+  );
+  return sorted[0]?.url ?? null;
+}

--- a/hub/src/services/fanarttv.ts
+++ b/hub/src/services/fanarttv.ts
@@ -49,15 +49,33 @@ export interface FanartTvArtistResponse {
   albums?: FanartTvAlbum[];
 }
 
+/** Minimal Fastify-compatible logger surface. */
+export interface FanartTvLogger {
+  error: (msg: string) => void;
+  info?: (msg: string) => void;
+}
+
+/** Per-request timeout for fanart.tv calls. Failures fall through to "no result". */
+const REQUEST_TIMEOUT_MS = 10_000;
+
 export class FanartTvClient {
   private readonly projectKey: string;
   private readonly personalKey: string | undefined;
   private readonly baseUrl: string;
+  private readonly log: FanartTvLogger;
 
-  constructor(opts: { projectKey: string; personalKey?: string; baseUrl?: string }) {
+  constructor(opts: {
+    projectKey: string;
+    personalKey?: string;
+    baseUrl?: string;
+    log?: FanartTvLogger;
+  }) {
     this.projectKey = opts.projectKey;
     this.personalKey = opts.personalKey;
     this.baseUrl = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.log = opts.log ?? {
+      error: (msg) => console.error(msg),
+    };
   }
 
   isEnabled(): boolean {
@@ -75,15 +93,16 @@ export class FanartTvClient {
     try {
       const res = await fetch(this.buildUrl(path), {
         headers: { "user-agent": USER_AGENT },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
       if (res.status === 404) return null;
       if (!res.ok) {
-        console.error(`fanart.tv API error: ${res.status} ${res.statusText}`);
+        this.log.error(`fanart.tv API error: ${res.status} ${res.statusText}`);
         return null;
       }
       return (await res.json()) as T;
     } catch (err) {
-      console.error(`fanart.tv API request failed: ${err}`);
+      this.log.error(`fanart.tv API request failed: ${err}`);
       return null;
     }
   }

--- a/hub/src/services/fanarttv.ts
+++ b/hub/src/services/fanarttv.ts
@@ -26,10 +26,18 @@ export interface FanartTvImage {
 }
 
 export interface FanartTvAlbum {
+  /** Release-group MBID — present on the artist endpoint, absent on /music/albums/. */
+  mbid_id?: string;
   albumcover?: FanartTvImage[];
   cdart?: FanartTvImage[];
 }
 
+/**
+ * Artist endpoint response. The `albums` field is an **array** of album
+ * subtrees (each tagged with its release-group MBID), not a keyed object.
+ * The /music/albums/{rg-mbid} endpoint returns a similar shape but scoped to
+ * a single release group; callers should still iterate `albums` defensively.
+ */
 export interface FanartTvArtistResponse {
   name?: string;
   mbid_id?: string;
@@ -38,7 +46,7 @@ export interface FanartTvArtistResponse {
   hdmusiclogo?: FanartTvImage[];
   musiclogo?: FanartTvImage[];
   musicbanner?: FanartTvImage[];
-  albums?: Record<string, FanartTvAlbum>;
+  albums?: FanartTvAlbum[];
 }
 
 export class FanartTvClient {
@@ -108,14 +116,19 @@ export class FanartTvClient {
     );
   }
 
-  /** Best album cover for a given release-group MBID, looked up inside the response. */
+  /**
+   * Best album cover for a given release-group MBID. fanart.tv returns
+   * `albums` as an array of subtrees, each tagged with its `mbid_id`.
+   * The /music/albums/ endpoint returns the same shape with one entry.
+   */
   static bestAlbumCover(
     resp: FanartTvArtistResponse | null,
     releaseGroupMbid: string,
   ): string | null {
-    const album = resp?.albums?.[releaseGroupMbid];
-    if (!album) return null;
-    return pickFirstUrl(album.albumcover) ?? null;
+    if (!resp?.albums || resp.albums.length === 0) return null;
+    const match =
+      resp.albums.find((a) => a.mbid_id === releaseGroupMbid) ?? resp.albums[0];
+    return pickFirstUrl(match.albumcover) ?? null;
   }
 }
 

--- a/hub/test/external-art.test.ts
+++ b/hub/test/external-art.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { isAllowedExternalArtUrl } from "../src/routes/external-art.js";
+
+describe("isAllowedExternalArtUrl", () => {
+  it("allows assets.fanart.tv", () => {
+    expect(
+      isAllowedExternalArtUrl("https://assets.fanart.tv/fanart/music/x.jpg"),
+    ).toBe(true);
+  });
+
+  it("allows the bare fanart.tv host", () => {
+    expect(isAllowedExternalArtUrl("https://fanart.tv/some/path.jpg")).toBe(true);
+  });
+
+  it("allows other fanart.tv subdomains", () => {
+    expect(isAllowedExternalArtUrl("https://images.fanart.tv/x.jpg")).toBe(true);
+  });
+
+  it("rejects http (https only)", () => {
+    expect(isAllowedExternalArtUrl("http://assets.fanart.tv/x.jpg")).toBe(false);
+  });
+
+  it("rejects unrelated hostnames", () => {
+    expect(isAllowedExternalArtUrl("https://evil.example.com/x.jpg")).toBe(false);
+    expect(isAllowedExternalArtUrl("https://lastfm.freetls.fastly.net/x.jpg")).toBe(false);
+  });
+
+  it("rejects hostnames that merely contain 'fanart.tv' as a substring", () => {
+    expect(isAllowedExternalArtUrl("https://fanart.tv.evil.com/x.jpg")).toBe(false);
+    expect(isAllowedExternalArtUrl("https://notfanart.tv/x.jpg")).toBe(false);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(isAllowedExternalArtUrl("https://")).toBe(false);
+    expect(isAllowedExternalArtUrl("not a url")).toBe(false);
+  });
+
+  it("rejects internal/private hostnames", () => {
+    expect(isAllowedExternalArtUrl("https://localhost/x.jpg")).toBe(false);
+    expect(isAllowedExternalArtUrl("https://169.254.169.254/latest/meta-data")).toBe(false);
+  });
+
+  it("is case-insensitive on the hostname", () => {
+    expect(isAllowedExternalArtUrl("https://ASSETS.FANART.TV/x.jpg")).toBe(true);
+  });
+});

--- a/hub/test/fanarttv.test.ts
+++ b/hub/test/fanarttv.test.ts
@@ -98,15 +98,24 @@ describe("FanartTvClient", () => {
     ).toBe("high.jpg");
   });
 
-  it("bestAlbumCover looks up the album by release-group MBID", () => {
+  it("bestAlbumCover finds the matching release-group MBID in the albums array", () => {
     const resp = {
-      albums: {
-        "rg-1": { albumcover: [{ id: "100", url: "cover.jpg" }] },
-      },
+      albums: [
+        { mbid_id: "rg-1", albumcover: [{ id: "100", url: "cover.jpg" }] },
+        { mbid_id: "rg-2", albumcover: [{ id: "101", url: "other.jpg" }] },
+      ],
     };
     expect(FanartTvClient.bestAlbumCover(resp, "rg-1")).toBe("cover.jpg");
-    expect(FanartTvClient.bestAlbumCover(resp, "rg-other")).toBeNull();
+    expect(FanartTvClient.bestAlbumCover(resp, "rg-2")).toBe("other.jpg");
+    expect(FanartTvClient.bestAlbumCover({ albums: [] }, "rg-1")).toBeNull();
     expect(FanartTvClient.bestAlbumCover(null, "rg-1")).toBeNull();
+  });
+
+  it("bestAlbumCover falls back to the first entry when /music/albums/ returns one untagged group", () => {
+    const resp = {
+      albums: [{ albumcover: [{ id: "1", url: "only.jpg" }] }],
+    };
+    expect(FanartTvClient.bestAlbumCover(resp, "rg-anything")).toBe("only.jpg");
   });
 
   it("getAlbum hits the /music/albums/{mbid} path", async () => {

--- a/hub/test/fanarttv.test.ts
+++ b/hub/test/fanarttv.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for FanartTvClient.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FanartTvClient } from "../src/services/fanarttv.js";
+
+describe("FanartTvClient", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses default base URL and bundles project key in query string", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ artistthumb: [] }), { status: 200 }),
+    );
+
+    const client = new FanartTvClient({ projectKey: "PROJ" });
+    await client.getArtist("mbid-1");
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.origin + url.pathname).toBe(
+      "https://webservice.fanart.tv/v3.2/music/mbid-1",
+    );
+    expect(url.searchParams.get("api_key")).toBe("PROJ");
+    expect(url.searchParams.has("client_key")).toBe(false);
+  });
+
+  it("respects baseUrl override and adds personal client_key when present", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const client = new FanartTvClient({
+      projectKey: "PROJ",
+      personalKey: "PERSONAL",
+      baseUrl: "http://localhost:1234/v3.2/",
+    });
+    await client.getArtist("mbid-1");
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.origin).toBe("http://localhost:1234");
+    expect(url.pathname).toBe("/v3.2/music/mbid-1");
+    expect(url.searchParams.get("api_key")).toBe("PROJ");
+    expect(url.searchParams.get("client_key")).toBe("PERSONAL");
+  });
+
+  it("returns null on 404 (no artwork on file)", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("Not found", { status: 404 }));
+    const client = new FanartTvClient({ projectKey: "PROJ" });
+    expect(await client.getArtist("missing")).toBeNull();
+  });
+
+  it("returns null on non-OK responses without throwing", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("oops", { status: 500 }));
+    const client = new FanartTvClient({ projectKey: "PROJ" });
+    expect(await client.getArtist("mbid-1")).toBeNull();
+  });
+
+  it("returns null on network error without throwing", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("DNS"));
+    const client = new FanartTvClient({ projectKey: "PROJ" });
+    expect(await client.getArtist("mbid-1")).toBeNull();
+  });
+
+  it("bestArtistImage prefers thumb, then background", () => {
+    expect(
+      FanartTvClient.bestArtistImage({
+        artistthumb: [{ id: "1", url: "thumb.jpg" }],
+        artistbackground: [{ id: "2", url: "bg.jpg" }],
+      }),
+    ).toBe("thumb.jpg");
+
+    expect(
+      FanartTvClient.bestArtistImage({
+        artistbackground: [{ id: "2", url: "bg.jpg" }],
+      }),
+    ).toBe("bg.jpg");
+
+    expect(FanartTvClient.bestArtistImage({})).toBeNull();
+    expect(FanartTvClient.bestArtistImage(null)).toBeNull();
+  });
+
+  it("bestArtistImage prefers higher-liked entries", () => {
+    expect(
+      FanartTvClient.bestArtistImage({
+        artistthumb: [
+          { id: "1", url: "low.jpg", likes: "1" },
+          { id: "2", url: "high.jpg", likes: "9" },
+        ],
+      }),
+    ).toBe("high.jpg");
+  });
+
+  it("bestAlbumCover looks up the album by release-group MBID", () => {
+    const resp = {
+      albums: {
+        "rg-1": { albumcover: [{ id: "100", url: "cover.jpg" }] },
+      },
+    };
+    expect(FanartTvClient.bestAlbumCover(resp, "rg-1")).toBe("cover.jpg");
+    expect(FanartTvClient.bestAlbumCover(resp, "rg-other")).toBeNull();
+    expect(FanartTvClient.bestAlbumCover(null, "rg-1")).toBeNull();
+  });
+
+  it("getAlbum hits the /music/albums/{mbid} path", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const client = new FanartTvClient({ projectKey: "PROJ" });
+    await client.getAlbum("rg-mbid-1");
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string);
+    expect(url.pathname).toBe("/v3.2/music/albums/rg-mbid-1");
+  });
+
+  it("isEnabled requires a non-empty project key", () => {
+    expect(new FanartTvClient({ projectKey: "" }).isEnabled()).toBe(false);
+    expect(new FanartTvClient({ projectKey: "x" }).isEnabled()).toBe(true);
+  });
+});

--- a/hub/test/fanarttv.test.ts
+++ b/hub/test/fanarttv.test.ts
@@ -69,6 +69,52 @@ describe("FanartTvClient", () => {
     expect(await client.getArtist("mbid-1")).toBeNull();
   });
 
+  it("returns null on 429 rate-limit responses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Too Many Requests", { status: 429 }),
+    );
+    const client = new FanartTvClient({ projectKey: "PROJ" });
+    expect(await client.getArtist("mbid-1")).toBeNull();
+  });
+
+  it("logs failures via the injected logger", async () => {
+    const log = { error: vi.fn(), info: vi.fn() };
+    fetchMock.mockResolvedValueOnce(new Response("oops", { status: 500 }));
+    const client = new FanartTvClient({ projectKey: "PROJ", log });
+    await client.getArtist("mbid-1");
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining("fanart.tv API error: 500"),
+    );
+  });
+
+  it("logs network errors via the injected logger", async () => {
+    const log = { error: vi.fn() };
+    fetchMock.mockRejectedValueOnce(new Error("DNS"));
+    const client = new FanartTvClient({ projectKey: "PROJ", log });
+    await client.getArtist("mbid-1");
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining("fanart.tv API request failed"),
+    );
+  });
+
+  it("passes an AbortSignal so requests cannot hang forever", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    const client = new FanartTvClient({ projectKey: "PROJ" });
+    await client.getArtist("mbid-1");
+    const opts = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("treats AbortError (timeout) as a non-fatal failure", async () => {
+    const log = { error: vi.fn() };
+    fetchMock.mockRejectedValueOnce(new DOMException("aborted", "AbortError"));
+    const client = new FanartTvClient({ projectKey: "PROJ", log });
+    expect(await client.getArtist("mbid-1")).toBeNull();
+    expect(log.error).toHaveBeenCalled();
+  });
+
   it("bestArtistImage prefers thumb, then background", () => {
     expect(
       FanartTvClient.bestArtistImage({

--- a/hub/test/getcoverart-external.test.ts
+++ b/hub/test/getcoverart-external.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration tests for /rest/getCoverArt's external-URL passthrough
+ * (the fanart.tv path) — SSRF allowlist + content-type guard.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { buildApp } from "../src/server.js";
+import { setPassword } from "../src/auth/passwords.js";
+import { encodeCoverArtId } from "../src/library/cover-art.js";
+import type { FastifyInstance } from "fastify";
+import type { Config } from "../src/config.js";
+
+const testConfig: Partial<Config> = {
+  databasePath: ":memory:",
+  jwtSecret: "test-secret-key-for-testing-purposes",
+};
+
+function seedUser(app: FastifyInstance) {
+  const enc = setPassword("secret", app.passwordKey);
+  app.db
+    .prepare(
+      "INSERT INTO users (id, username, password_enc, is_admin) VALUES (?, ?, ?, 1)",
+    )
+    .run("user-1", "tester", enc);
+}
+
+function artUrl(encodedId: string): string {
+  return `/rest/getCoverArt?u=tester&p=secret&f=json&id=${encodeURIComponent(encodedId)}`;
+}
+
+describe("/rest/getCoverArt external URL passthrough", () => {
+  let app: FastifyInstance;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    app = await buildApp(testConfig);
+    await app.ready();
+    seedUser(app);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await app.close();
+  });
+
+  it("fetches an allowed fanart.tv URL and serves it as image bytes", async () => {
+    const png = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(png, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const id = encodeCoverArtId(
+      "local",
+      "https://assets.fanart.tv/fanart/music/abc.png",
+    );
+    const res = await app.inject({ method: "GET", url: artUrl(id) });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("image/png");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://assets.fanart.tv/fanart/music/abc.png",
+    );
+  });
+
+  it("rejects a non-allowlisted hostname with 400 and never fetches", async () => {
+    const id = encodeCoverArtId("local", "https://evil.example.com/x.jpg");
+    const res = await app.inject({ method: "GET", url: artUrl(id) });
+
+    expect(res.statusCode).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects http:// (https only) with 400 and never fetches", async () => {
+    const id = encodeCoverArtId("local", "http://assets.fanart.tv/x.jpg");
+    const res = await app.inject({ method: "GET", url: artUrl(id) });
+
+    expect(res.statusCode).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats an HTML response from an allowed host as 404 (not cached)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("<html>not an image</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    const id = encodeCoverArtId(
+      "local",
+      "https://assets.fanart.tv/fanart/music/abc.png",
+    );
+    const res = await app.inject({ method: "GET", url: artUrl(id) });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 502 when the external fetch throws", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("DNS"));
+    const id = encodeCoverArtId(
+      "local",
+      "https://assets.fanart.tv/fanart/music/abc.png",
+    );
+    const res = await app.inject({ method: "GET", url: artUrl(id) });
+    expect(res.statusCode).toBe(502);
+  });
+});

--- a/hub/test/sync-fanarttv.test.ts
+++ b/hub/test/sync-fanarttv.test.ts
@@ -261,11 +261,12 @@ describe("fanart.tv integration during sync", () => {
 
     fanartMock.mockResolvedValueOnce(
       jsonResponse({
-        albums: {
-          "rg-okc": {
+        albums: [
+          {
+            mbid_id: "rg-okc",
             albumcover: [{ id: "9", url: "https://fanart.tv/okc.jpg" }],
           },
-        },
+        ],
       }),
     );
 

--- a/hub/test/sync-fanarttv.test.ts
+++ b/hub/test/sync-fanarttv.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Functional tests for fanart.tv integration during library sync (#131).
+ *
+ *  1. Artists with an MBID get their image from fanart.tv (preferred over Navidrome's).
+ *  2. Albums with a release-group MBID and no Navidrome cover get one from fanart.tv.
+ *  3. fanart.tv is not consulted for artists without an MBID.
+ *  4. fanart.tv failure falls back to Navidrome's image.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import crypto from "node:crypto";
+import Database from "better-sqlite3";
+import { createDatabase } from "../src/db/client.js";
+import { syncLocal } from "../src/library/sync-local.js";
+import type { Config } from "../src/config.js";
+import { FanartTvClient } from "../src/services/fanarttv.js";
+import { seedSyntheticInstances } from "../src/library/seed-instances.js";
+
+function subsonicResponse(payload: Record<string, unknown>) {
+  return {
+    "subsonic-response": {
+      status: "ok",
+      version: "1.16.1",
+      type: "navidrome",
+      serverVersion: "0.53.3",
+      openSubsonic: true,
+      ...payload,
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const TEST_BASE_URL = "http://fanarttv.test/v3.2";
+
+function seedAndConfig(db: Database.Database) {
+  seedSyntheticInstances(
+    db,
+    {
+      databasePath: ":memory:",
+      navidromeUrl: "http://navidrome:4533",
+      navidromeUsername: "test",
+      navidromePassword: "test",
+      poutineInstanceId: "test-instance",
+      poutinePeersConfig: "{}",
+      instanceConcurrency: 3,
+    } as unknown as Config,
+    {
+      instanceId: "test-instance",
+      peers: new Map(),
+      reload: () => {},
+    } as unknown as Parameters<typeof seedSyntheticInstances>[2],
+  );
+
+  return {
+    databasePath: ":memory:",
+    navidromeUrl: "http://navidrome:4533",
+    navidromeUsername: "test",
+    navidromePassword: "test",
+    poutineInstanceId: "test-instance",
+    poutinePeersConfig: "{}",
+    instanceConcurrency: 1,
+  } as unknown as Config;
+}
+
+describe("fanart.tv integration during sync", () => {
+  let db: Database.Database;
+  let subsonicMock: ReturnType<typeof vi.fn>;
+  let fanartMock: ReturnType<typeof vi.fn>;
+  let client: FanartTvClient;
+
+  beforeEach(() => {
+    db = createDatabase(":memory:");
+    client = new FanartTvClient({ projectKey: "PROJ", baseUrl: TEST_BASE_URL });
+
+    subsonicMock = vi.fn();
+    fanartMock = vi.fn();
+
+    vi.spyOn(global, "fetch").mockImplementation(async (input: unknown) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.startsWith(TEST_BASE_URL)) return fanartMock(url);
+      return subsonicMock(url);
+    });
+
+    vi.spyOn(crypto, "randomBytes").mockReturnValue(
+      Buffer.from("abcdef123456abcdef123456", "hex") as unknown as Buffer,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    db.close();
+  });
+
+  it("uses fanart.tv as primary source for artists with an MBID", async () => {
+    subsonicMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artists: {
+              index: [
+                {
+                  name: "R",
+                  artist: [{ id: "ar-1", name: "Radiohead" }],
+                },
+              ],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artist: {
+              id: "ar-1",
+              name: "Radiohead",
+              musicBrainzId: "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+              coverArt: "navidrome-cover-art-123",
+              album: [],
+            },
+          }),
+        ),
+      );
+
+    fanartMock.mockResolvedValueOnce(
+      jsonResponse({
+        artistthumb: [{ id: "1", url: "https://fanart.tv/radiohead-thumb.jpg" }],
+        artistbackground: [{ id: "2", url: "https://fanart.tv/radiohead-bg.jpg" }],
+      }),
+    );
+
+    const config = seedAndConfig(db);
+    await syncLocal(db, config, null, client);
+
+    expect(fanartMock).toHaveBeenCalledTimes(1);
+    const fanartUrl = new URL(fanartMock.mock.calls[0][0] as string);
+    expect(fanartUrl.pathname).toBe(
+      "/v3.2/music/a74b1b7f-71a5-4011-9441-d0b5e4122711",
+    );
+    expect(fanartUrl.searchParams.get("api_key")).toBe("PROJ");
+
+    const row = db
+      .prepare(
+        "SELECT image_url FROM instance_artists WHERE instance_id = ? AND remote_id = ?",
+      )
+      .get("local", "ar-1") as { image_url: string };
+    expect(row.image_url).toBe("https://fanart.tv/radiohead-thumb.jpg");
+  });
+
+  it("falls back to Navidrome cover when fanart.tv has no image for the MBID", async () => {
+    subsonicMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artists: {
+              index: [{ name: "R", artist: [{ id: "ar-1", name: "Radiohead" }] }],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artist: {
+              id: "ar-1",
+              name: "Radiohead",
+              musicBrainzId: "rg-mbid",
+              coverArt: "navidrome-cover-art-123",
+              album: [],
+            },
+          }),
+        ),
+      );
+
+    fanartMock.mockResolvedValueOnce(new Response("Not found", { status: 404 }));
+
+    const config = seedAndConfig(db);
+    await syncLocal(db, config, null, client);
+
+    const row = db
+      .prepare(
+        "SELECT image_url FROM instance_artists WHERE instance_id = ? AND remote_id = ?",
+      )
+      .get("local", "ar-1") as { image_url: string };
+    expect(row.image_url).toBe("navidrome-cover-art-123");
+  });
+
+  it("does NOT call fanart.tv for artists without an MBID", async () => {
+    subsonicMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artists: {
+              index: [{ name: "U", artist: [{ id: "ar-1", name: "Unknown" }] }],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artist: {
+              id: "ar-1",
+              name: "Unknown",
+              coverArt: "nd-cover",
+              album: [],
+            },
+          }),
+        ),
+      );
+
+    const config = seedAndConfig(db);
+    await syncLocal(db, config, null, client);
+
+    expect(fanartMock).not.toHaveBeenCalled();
+    const row = db
+      .prepare("SELECT image_url FROM instance_artists WHERE remote_id = ?")
+      .get("ar-1") as { image_url: string };
+    expect(row.image_url).toBe("nd-cover");
+  });
+
+  it("uses fanart.tv album cover when album has release-group MBID and no Navidrome cover", async () => {
+    subsonicMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artists: {
+              index: [{ name: "R", artist: [{ id: "ar-1", name: "Radiohead" }] }],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artist: {
+              id: "ar-1",
+              name: "Radiohead",
+              album: [{ id: "al-1", name: "OK Computer" }],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            album: {
+              id: "al-1",
+              name: "OK Computer",
+              releaseGroupMbid: "rg-okc",
+              // No coverArt — triggers fanart.tv lookup.
+              song: [],
+            },
+          }),
+        ),
+      );
+
+    fanartMock.mockResolvedValueOnce(
+      jsonResponse({
+        albums: {
+          "rg-okc": {
+            albumcover: [{ id: "9", url: "https://fanart.tv/okc.jpg" }],
+          },
+        },
+      }),
+    );
+
+    const config = seedAndConfig(db);
+    await syncLocal(db, config, null, client);
+
+    const fanartCalls = fanartMock.mock.calls.map((c) => c[0] as string);
+    const albumCall = fanartCalls.find((u) => u.includes("/albums/rg-okc"));
+    expect(albumCall).toBeDefined();
+
+    const row = db
+      .prepare(
+        "SELECT cover_art_id FROM instance_albums WHERE instance_id = ? AND remote_id = ?",
+      )
+      .get("local", "al-1") as { cover_art_id: string };
+    expect(row.cover_art_id).toBe("https://fanart.tv/okc.jpg");
+  });
+
+  it("does NOT call fanart.tv for an album when Navidrome already provides a cover", async () => {
+    subsonicMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artists: {
+              index: [{ name: "R", artist: [{ id: "ar-1", name: "Radiohead" }] }],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artist: {
+              id: "ar-1",
+              name: "Radiohead",
+              album: [{ id: "al-1", name: "OK Computer" }],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            album: {
+              id: "al-1",
+              name: "OK Computer",
+              releaseGroupMbid: "rg-okc",
+              coverArt: "nd-cover-okc",
+              song: [],
+            },
+          }),
+        ),
+      );
+
+    const config = seedAndConfig(db);
+    await syncLocal(db, config, null, client);
+
+    const albumCalls = fanartMock.mock.calls
+      .map((c) => c[0] as string)
+      .filter((u) => u.includes("/albums/"));
+    expect(albumCalls).toHaveLength(0);
+
+    const row = db
+      .prepare(
+        "SELECT cover_art_id FROM instance_albums WHERE remote_id = ?",
+      )
+      .get("al-1") as { cover_art_id: string };
+    expect(row.cover_art_id).toBe("nd-cover-okc");
+  });
+
+  it("handles fanart.tv API failure gracefully", async () => {
+    subsonicMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artists: {
+              index: [{ name: "R", artist: [{ id: "ar-1", name: "Radiohead" }] }],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          subsonicResponse({
+            artist: {
+              id: "ar-1",
+              name: "Radiohead",
+              musicBrainzId: "mbid-x",
+              coverArt: "nd-cover",
+              album: [],
+            },
+          }),
+        ),
+      );
+
+    fanartMock.mockRejectedValueOnce(new Error("network"));
+
+    const config = seedAndConfig(db);
+    const result = await syncLocal(db, config, null, client);
+
+    expect(result.errors).toHaveLength(0);
+    const row = db
+      .prepare("SELECT image_url FROM instance_artists WHERE remote_id = ?")
+      .get("ar-1") as { image_url: string };
+    expect(row.image_url).toBe("nd-cover");
+  });
+});

--- a/hub/test/sync-lastfm.test.ts
+++ b/hub/test/sync-lastfm.test.ts
@@ -84,8 +84,10 @@ describe("Last.fm integration during sync", () => {
 
   // ── Tests ─────────────────────────────────────────────────────────────────
 
-  it("calls Last.fm when artist has no cover art from Navidrome", async () => {
-    // Setup: Navidrome returns artist without coverArt
+  it("calls Last.fm when artist has no cover art and no MBID", async () => {
+    // Setup: Navidrome returns artist without coverArt or MBID. Per #131,
+    // Last.fm is the fallback only when no MBID is available — artists with
+    // an MBID go through fanart.tv instead.
     const mockArtistsResponse = subsonicResponse({
       artists: {
         index: [
@@ -103,9 +105,8 @@ describe("Last.fm integration during sync", () => {
       artist: {
         id: "ar-1",
         name: "Radiohead",
-        musicBrainzId: "a74b1b7f-71a5-4011-9441-d0b5e4122711",
         albumCount: 10,
-        // NO coverArt - this triggers Last.fm lookup
+        // NO coverArt and NO MBID - this triggers Last.fm lookup
         album: [
           { id: "al-1", name: "OK Computer", artist: "Radiohead", songCount: 12 },
         ],
@@ -189,8 +190,9 @@ describe("Last.fm integration during sync", () => {
     const lastFmCall = lastFmFetchMock.mock.calls[0][0] as string;
     expect(lastFmCall).toContain("ws.audioscrobbler.com");
     expect(lastFmCall).toContain("method=artist.getinfo");
-    // When MusicBrainz ID is available, it's used for more accurate lookup
-    expect(lastFmCall).toContain("mbid=a74b1b7f-71a5-4011-9441-d0b5e4122711");
+    // No MBID → Last.fm is queried by artist name.
+    expect(lastFmCall).toContain("artist=Radiohead");
+    expect(lastFmCall).not.toContain("mbid=");
 
     // Verify artist image was stored in database
     const artistRow = db.prepare(
@@ -310,9 +312,8 @@ describe("Last.fm integration during sync", () => {
       artist: {
         id: "ar-1",
         name: "Unknown Band",
-        musicBrainzId: "unknown-mbid",
         albumCount: 5,
-        // NO coverArt
+        // NO coverArt and no MBID → falls back to Last.fm.
         album: [
           { id: "al-1", name: "Debut Album", artist: "Unknown Band", songCount: 10 },
         ],
@@ -386,8 +387,10 @@ describe("Last.fm integration during sync", () => {
     expect(artistRow.image_url).toBeNull(); // No image because Last.fm failed
   });
 
-  it("uses MusicBrainz ID when available for Last.fm lookup", async () => {
-    // Setup: Navidrome returns artist with MusicBrainz ID but no coverArt
+  it("does NOT call Last.fm when artist has an MBID (fanart.tv handles those)", async () => {
+    // Per #131: Last.fm is the fallback only for artists without an MBID.
+    // When an MBID is present, fanart.tv is the primary source and Last.fm
+    // is skipped entirely.
     const mockArtistsResponse = subsonicResponse({
       artists: {
         index: [
@@ -456,13 +459,12 @@ describe("Last.fm integration during sync", () => {
       instanceConcurrency: 1,
     } as unknown as Config;
 
-    // Run sync with Last.fm enabled
-    await syncLocal(db, testConfig, lastFmClient);
+    // Run sync with Last.fm enabled and no fanart.tv client (so the MBID
+    // pathway is fully skipped instead of routed to fanart.tv).
+    await syncLocal(db, testConfig, lastFmClient, null);
 
-    // Verify Last.fm was called with MusicBrainz ID
-    expect(lastFmFetchMock).toHaveBeenCalledTimes(1);
-    const lastFmCall = lastFmFetchMock.mock.calls[0][0] as string;
-    expect(lastFmCall).toContain("mbid=a74b1b7f-71a5-4011-9441-d0b5e4122711");
-    expect(lastFmCall).not.toContain("artist=Radiohead"); // Should use mbid, not artist name
+    // Verify Last.fm was NOT called — the artist has an MBID so it would go
+    // through fanart.tv, not Last.fm.
+    expect(lastFmFetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- fanart.tv is now the **primary** source for artist images when an MBID is available, and a fallback for album covers when an album has a release-group MBID but no Navidrome cover.
- Last.fm is demoted to a fallback for artists *without* an MBID, and only when `LASTFM_API_KEY` is configured.
- Ships with a bundled Poutine project key — no setup required. Overridable via `FANARTTV_API_KEY` / `FANARTTV_CLIENT_KEY` / `FANARTTV_API_URL`.
- `/rest/getCoverArt` now serves external `https://` URLs directly so fanart.tv-sourced album covers reuse the existing cover-art ID flow.

Closes #131.

## Resolution chain

| Scope    | 1                              | 2                       | 3                                  |
|----------|--------------------------------|-------------------------|------------------------------------|
| Artist   | fanart.tv (if MBID)            | Navidrome `coverArt`    | Last.fm (no MBID, key configured)  |
| Album    | Navidrome `coverArt`           | fanart.tv (if RG MBID)  | —                                  |

## Files

- `hub/src/services/fanarttv.ts` — new client.
- `hub/src/library/sync-instance.ts` — primary/fallback resolution for artists + album-cover fallback.
- `hub/src/routes/subsonic.ts` — `getCoverArt` passthrough for external URLs.
- Wiring: `config.ts`, `server.ts`, `auto-sync.ts`, `sync.ts`, `sync-local.ts`, `sync-peer.ts`.
- Tests: `fanarttv.test.ts` (unit), `sync-fanarttv.test.ts` (integration), `sync-lastfm.test.ts` (updated for new fallback semantics).
- Docs: new `docs/fanarttv-integration.md`; `docs/lastfm-integration.md`, `docs/hub-internals.md`, `AGENTS.md`, `example.env` updated.

## Test plan

- [x] `pnpm typecheck` (hub + frontend)
- [x] `pnpm test` (345 tests pass; 6 new fanart.tv sync tests, 10 new client unit tests)
- [ ] Manual: enable on the live instance, trigger a sync, verify artist images appear for MBID-known artists and that Navidrome covers still serve for known albums
- [ ] Manual: confirm `getCoverArt` serves a fanart.tv URL when an album has no Navidrome cover

🤖 Generated with [Claude Code](https://claude.com/claude-code)