### PR TITLE
fix(subsonic): default response format to XML per spec

### DIFF
--- a/docs/opensubsonic.md
+++ b/docs/opensubsonic.md
@@ -13,7 +13,7 @@ Poutine implements the [OpenSubsonic API](https://opensubsonic.netlify.app/) —
 
 ## Response formats
 
-Both JSON (`f=json`, default) and XML (`f=xml`) supported. Default is JSON.
+Both JSON (`f=json`) and XML (`f=xml`) supported. Default is XML when `f=` is omitted, per Subsonic spec — clients like Amperfy and Feishin probe without `f=` and fail to parse a JSON envelope (surfaces as an auth error).
 
 ## Auth
 

--- a/hub/src/routes/subsonic-response.ts
+++ b/hub/src/routes/subsonic-response.ts
@@ -7,8 +7,11 @@ export const SERVER_VERSION = APP_VERSION;
 
 export type Format = "json" | "xml";
 
+// Subsonic spec: default response format is XML when `f=` is omitted.
+// Clients that don't ask for JSON (e.g. Amperfy, Feishin probing /rest/ping)
+// fail to parse a JSON envelope and surface the failure as an auth error.
 export function getFormat(query: Record<string, string>): Format {
-  return query.f === "xml" ? "xml" : "json";
+  return query.f === "json" ? "json" : "xml";
 }
 
 // ── XML serializer ────────────────────────────────────────────────────────────

--- a/hub/test/subsonic-routes.test.ts
+++ b/hub/test/subsonic-routes.test.ts
@@ -78,6 +78,17 @@ describe("Subsonic routes — auth", () => {
     expect(body["subsonic-response"].status).toBe("ok");
   });
 
+  it("ping with no f= param → defaults to XML (Subsonic spec)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/ping?u=tester&p=secret",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/application\/xml/);
+    expect(res.body).toMatch(/^<\?xml/);
+    expect(res.body).toContain('status="ok"');
+  });
+
   it("ping with f=xml → XML content-type and correct envelope", async () => {
     const res = await app.inject({
       method: "GET",


### PR DESCRIPTION
## Summary
- `getFormat()` now returns `xml` when the `f=` query param is missing, matching the Subsonic spec.
- Amperfy / Feishin (and likely other clients) probe `/rest/ping` without `f=` and expect XML; defaulting to JSON made them surface the parse failure as an authentication error.
- JSON remains opt-in via `f=json` — used by the SPA (`frontend/src/lib/subsonic.ts`) and federated sync, both of which set the param explicitly.

Closes #164.

## Test plan
- [x] `pnpm --filter hub test` (388/388 pass) — new regression test asserts XML content-type when `f=` is omitted.
- [x] `pnpm --filter hub typecheck`
- [x] Manual: Amperfy login against music-west succeeds end-to-end with correct password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)