### PR TITLE
feat(subsonic): implement /rest/getUser for Feishin (#166)

### DIFF
--- a/docs/opensubsonic.md
+++ b/docs/opensubsonic.md
@@ -192,7 +192,7 @@ clients behave correctly without per-client workarounds.
 
 | Endpoint         | Status          | Notes |
 |------------------|-----------------|-------|
-| `getUser`        | NOT IMPLEMENTED |       |
+| `getUser`        | IMPLEMENTED     | Returns auth'd user's roles (admin from `users.is_admin`); non-admin requesting another username → error 50. Required by Feishin login. |
 | `getUsers`       | NOT IMPLEMENTED |       |
 | `createUser`     | NOT IMPLEMENTED |       |
 | `updateUser`     | NOT IMPLEMENTED |       |

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -325,6 +325,47 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
     });
   });
 
+  // ── getUser ─────────────────────────────────────────────────────────────────
+
+  route("/getUser", async (request, reply) => {
+    const q = request.query as Record<string, string>;
+    const auth = request.subsonicUser!;
+    const requested = (q.username || "").trim();
+    // Subsonic spec: non-admins may only fetch their own record.
+    if (requested && requested !== auth.username && !auth.isAdmin) {
+      sendSubsonicError(reply, 50, "User is not authorized for the given operation.", q);
+      return;
+    }
+    const targetName = requested || auth.username;
+    const row = app.db
+      .prepare("SELECT username, is_admin FROM users WHERE username = ?")
+      .get(targetName) as { username: string; is_admin: number } | undefined;
+    if (!row) {
+      sendSubsonicError(reply, 70, "User not found.", q);
+      return;
+    }
+    const isAdmin = row.is_admin === 1;
+    sendSubsonicOk(reply, q, {
+      user: {
+        username: row.username,
+        email: "",
+        scrobblingEnabled: true,
+        adminRole: isAdmin,
+        settingsRole: isAdmin,
+        downloadRole: true,
+        uploadRole: false,
+        playlistRole: true,
+        coverArtRole: true,
+        commentRole: false,
+        podcastRole: false,
+        streamRole: true,
+        jukeboxRole: false,
+        shareRole: false,
+        videoConversionRole: false,
+      },
+    });
+  });
+
   // ── getMusicFolders ─────────────────────────────────────────────────────────
 
   route("/getMusicFolders", async (request, reply) => {

--- a/hub/test/subsonic-routes.test.ts
+++ b/hub/test/subsonic-routes.test.ts
@@ -194,6 +194,44 @@ describe("Subsonic routes — endpoints", () => {
     expect(body["subsonic-response"].genres).toHaveProperty("genre");
   });
 
+  it("getUser → returns authenticated user with admin roles", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getUser?u=tester&p=secret&f=json",
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body["subsonic-response"].status).toBe("ok");
+    expect(body["subsonic-response"].user.username).toBe("tester");
+    expect(body["subsonic-response"].user.adminRole).toBe(true);
+    expect(body["subsonic-response"].user.streamRole).toBe(true);
+  });
+
+  it("getUser.view (Feishin style) → ok", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getUser.view?u=tester&p=secret&f=json&username=tester",
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body["subsonic-response"].status).toBe("ok");
+    expect(body["subsonic-response"].user.username).toBe("tester");
+  });
+
+  it("getUser as non-admin requesting other user → error 50", async () => {
+    const enc = setPassword("pw2", app.passwordKey);
+    app.db
+      .prepare("INSERT INTO users (id, username, password_enc, is_admin) VALUES (?, ?, ?, 0)")
+      .run("user-2", "alice", enc);
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getUser?u=alice&p=pw2&f=json&username=tester",
+    });
+    const body = res.json();
+    expect(body["subsonic-response"].status).toBe("failed");
+    expect(body["subsonic-response"].error.code).toBe(50);
+  });
+
   it("getLicense → valid license", async () => {
     const res = await app.inject({
       method: "GET",


### PR DESCRIPTION
## Summary
- Adds `/rest/getUser` Subsonic endpoint. Feishin calls it immediately on login; the 404 was killing auth.
- Returns auth'd user's roles; `adminRole`/`settingsRole` from `users.is_admin`. Non-admin requesting another username → error 50; unknown user → error 70.
- Docs + 3 tests (basic, `.view` suffix, non-admin authz).

Closes #166

## Test plan
- [x] `pnpm test` (391 pass)
- [x] `pnpm typecheck` clean
- [x] Verify Feishin login against live instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)