### PR TITLE
docs: refresh system-architecture for stars, playlists, MusicFolders, external art

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,18 +18,19 @@ Poutine: federated music player. Hub (Fastify + SQLite) bundles an internal Navi
 
 ## Per-task checklist
 
-1. Open or assign a GitHub Issue.
-2. Read the relevant doc(s):
+1. **Start every task by reading `docs/system-architecture.md`.** It is short by design. No exceptions.
+2. Open or assign a GitHub Issue.
+3. Read the relevant doc(s):
    - Touching auth, JWT, login, tokens, or Subsonic credentials: read `docs/authentication.md` FIRST.
    - Touching `/federation/*`: read `docs/federation-api.md` FIRST. Update it AND bump `FEDERATION_API_VERSION` in `hub/src/version.ts` on any contract change.
    - Touching hub internals, conventions, or anything with a known gotcha: check `docs/hub-internals.md`.
-   - Architectural changes: read `docs/system-architecture.md`.
-3. Write tests alongside code. Run `pnpm test` + `pnpm typecheck` before declaring done.
+   - Architectural changes: update `docs/system-architecture.md` as part of the work.
+4. Write tests alongside code. Run `pnpm verify` (typecheck + test) before declaring done.
    - When querying the live database: check `hub/src/db/schema.sql` for the schema, then use `scripts/db-query.sh "SQL"`. Never exec into the container and try to import `better-sqlite3` manually.
-4. Update documentation and check for any outdated or inconsistent information.
-6. Commit work in phases, when all tests are passing
-7. Push branch to origin
-8. When work is completed, open a Pull Request in the Draft state
+5. Update documentation and check for any outdated or inconsistent information.
+6. Commit work in phases, when all tests are passing.
+7. Push branch to origin.
+8. When work is completed, open a Pull Request in the Draft state.
 
 ## Documentation rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Poutine: federated music player. Hub (Fastify + SQLite) bundles an internal Navi
 
 ## Per-task checklist
 
-1. **Start every task by reading `docs/system-architecture.md`.** It is short by design. No exceptions.
+1. **Start every task by reading `docs/system-architecture.md` and skimming `docs/pitfalls.md`.** Both are short by design. No exceptions.
 2. Open or assign a GitHub Issue.
 3. Read the relevant doc(s):
    - Touching auth, JWT, login, tokens, or Subsonic credentials: read `docs/authentication.md` FIRST.
@@ -40,7 +40,7 @@ Poutine: federated music player. Hub (Fastify + SQLite) bundles an internal Navi
 - **Condense, don't duplicate.** If something is documented once, reference it by path — do not copy it.
 - **Terse, technical language.** Fragments OK. Audience: coding agents and experienced engineers, not newcomers.
 - **Markdown tables:** pad headers and rows so columns align vertically in source.
-- **When you learn a new gotcha:** add it to the relevant section of `docs/`, not AGENTS.md.
+- **When you learn a new gotcha:** add it to `docs/pitfalls.md` (or the relevant section of `docs/` if it's narrow), not AGENTS.md.
 
 ## Pointers
 
@@ -49,7 +49,8 @@ Poutine: federated music player. Hub (Fastify + SQLite) bundles an internal Navi
 | `README.md`                          | Setup, commands, testing, operations                             |
 | `docs/authentication.md`             | **Auth reference** — JWT, Subsonic dual-auth, token refresh      |
 | `docs/federation-api.md`             | **Federation protocol contract** — read before `/federation/*`   |
-| `docs/hub-internals.md`              | Conventions, env vars, gotchas, lessons learned, Docker          |
+| `docs/hub-internals.md`              | Conventions, env vars, lessons learned, Docker                   |
+| `docs/pitfalls.md`                   | **Recurring traps** — check before touching merge, SQLite, auth, federation, external fetches |
 | `docs/opensubsonic.md`               | OpenSubsonic endpoint compatibility table and caveats            |
 | `hub/src/db/schema.sql`              | Canonical DB schema — source of truth; read before writing DB queries |
 | `scripts/db-query.sh`               | Run ad-hoc SQL against the live hub DB via `docker compose`       |

--- a/docs/hub-internals.md
+++ b/docs/hub-internals.md
@@ -1,6 +1,6 @@
 # Hub internals
 
-Engineering reference for working on the hub (`hub/`) and frontend (`frontend/`). Audience: coding agents and senior engineers. For the federation protocol contract, see [federation-api.md](federation-api.md). For the high-level architecture, see [system-architecture.md](system-architecture.md).
+Engineering reference for working on the hub (`hub/`) and frontend (`frontend/`). Audience: coding agents and senior engineers. For the federation protocol contract, see [federation-api.md](federation-api.md). For the high-level architecture, see [system-architecture.md](system-architecture.md). For recurring failure modes, see [pitfalls.md](pitfalls.md).
 
 ## Repo structure
 

--- a/docs/hub-internals.md
+++ b/docs/hub-internals.md
@@ -1,6 +1,6 @@
 # Hub internals
 
-Engineering reference for working on the hub (`hub/`) and frontend (`frontend/`). Audience: coding agents and senior engineers. For the federation protocol contract, see [federation-api.md](federation-api.md). For the high-level architecture, see [02-system-architecture.md](02-system-architecture.md).
+Engineering reference for working on the hub (`hub/`) and frontend (`frontend/`). Audience: coding agents and senior engineers. For the federation protocol contract, see [federation-api.md](federation-api.md). For the high-level architecture, see [system-architecture.md](system-architecture.md).
 
 ## Repo structure
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1,0 +1,96 @@
+# Pitfalls
+
+Recurring traps that have caused bugs and follow-up PRs. Read before touching the relevant area. New traps go here, not in commit messages or PR comments.
+
+## Merge / unified IDs
+
+| Trap                                                                                                                                                   | Caught by | Rule                                                                                                                                |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `unified_releases.id` collision when two non-MBID releases share a name in the same release group                                                      | #117      | Dedup keys must include enough discriminator (track count, year, format) to survive upstreams that omit MBIDs                       |
+| Same recording MBID appearing on distinct releases collapsed into one `unified_tracks` row                                                             | #118      | A recording MBID is not unique across releases — key tracks by (release_id, mbid) not mbid alone                                    |
+| Per-track artist collapsed into album artist during unification                                                                                        | #142      | Resolve track artist from `instance_tracks.artist_name`, never from the album row                                                   |
+
+Every `unified_*` insert in `merge.ts` logs the offending row + prior `existingRow` + source IDs on PK conflict. Preserve that — it is the first thing you read when a collision regresses.
+
+## SQLite quirks
+
+| Trap                                                                       | Caught by | Rule                                                                                       |
+|----------------------------------------------------------------------------|-----------|--------------------------------------------------------------------------------------------|
+| `ALTER TABLE … ADD COLUMN … UNIQUE` fails on SQLite                       | #123      | Add the column unconstrained, then create a `UNIQUE INDEX` in a separate migration step    |
+| Forgetting to read `hub/src/db/schema.sql` before writing queries          | recurring | Schema is authoritative — check it, then use `scripts/db-query.sh` for ad-hoc reads        |
+| `exec`-ing into the container to import `better-sqlite3` manually          | recurring | Always go through `scripts/db-query.sh`                                                    |
+
+## Subsonic API compatibility
+
+| Trap                                                                                                              | Caught by | Rule                                                                                                |
+|-------------------------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------------|
+| Defaulting response format to JSON                                                                                | #164      | Per spec, default is XML. JSON is opt-in (`f=json`). 3rd-party clients surface JSON as auth failure |
+| Stream params (`format`, `maxBitRate`) dropped on peer-routed streams                                             | #77, #91  | `buildStreamParams` is the only allowlist — both local and peer paths go through it                 |
+| Treating any `https?://…` ID as a coverArt key                                                                    | #140      | Star/getCoverArt classifiers must be UUID-shaped; non-UUID IDs are external URLs                    |
+| Caching Navidrome's "missing cover" XML envelope as if it were an image                                           | recurring | Validate content-type + magic bytes before writing to `art_cache`                                   |
+| Not honoring caller transcode params when recording proxy stream activity                                         | recurring | Use the resolved params (after `buildStreamParams`), not the raw request                            |
+
+Endpoint coverage detail: [opensubsonic.md](opensubsonic.md).
+
+## External fetches (cover art, fanart.tv, Last.fm)
+
+| Trap                                                                          | Caught by | Rule                                                                                                       |
+|-------------------------------------------------------------------------------|-----------|------------------------------------------------------------------------------------------------------------|
+| SSRF via 3rd-party-client `getCoverArt` URLs                                  | #139      | Allowlist on scheme + host; reject anything resolving to private/loopback ranges                          |
+| Echoing raw `String(err)` in the 502 response                                 | #139      | Internal error detail never leaves the hub — log it, return a generic message                              |
+| No request timeout on external HTTP                                           | #139      | All `undici` calls take an explicit `bodyTimeout` / `headersTimeout`                                       |
+| Calling Navidrome `getArtistInfo2`                                            | recurring | Navidrome doesn't implement it. Fetch from Last.fm/fanart.tv directly                                       |
+| `import type` for a runtime value (e.g. `FanartTvClient`)                     | recurring | If you call `new X()`, import it as a value, not a type                                                    |
+
+## Federation
+
+| Trap                                                                                                                              | Caught by | Rule                                                                                                                 |
+|-----------------------------------------------------------------------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------|
+| TOCTOU between "SELECT invitation WHERE consumed_at IS NULL" and the admit transaction                                            | #156      | Nonce consumption must be a single atomic `UPDATE … WHERE consumed_at IS NULL RETURNING …`                           |
+| Auto-sync `setInterval` / `setTimeout` blocking graceful shutdown                                                                 | #156      | `.unref()` every long-lived timer                                                                                    |
+| Gossip pinning the inviter pubkey to whatever the gossip claims                                                                   | #156      | Trust is transitive only via the invitation chain — only pin from known inviters; verify embedded signature          |
+| Trusting `String(remoteErr)` from a peer in a 502                                                                                 | #156      | Same as external fetches — never echo upstream error text                                                            |
+| Changing a `/federation/*` contract without bumping `FEDERATION_API_VERSION` in `hub/src/version.ts` and updating federation-api.md | recurring | Contract is the doc; the doc is the contract. Bump both together                                                     |
+
+Full protocol: [federation-api.md](federation-api.md).
+
+## Auth
+
+| Trap                                                                                  | Caught by | Rule                                                                                                          |
+|---------------------------------------------------------------------------------------|-----------|---------------------------------------------------------------------------------------------------------------|
+| Hashing passwords (bcrypt/argon2)                                                     | design    | Subsonic `u+t+s` requires the cleartext — passwords are AES-256-GCM-encrypted, not hashed                     |
+| `reset-password.sh` calling a hash helper                                             | #114      | Reset must go through the AES path, same as user creation                                                     |
+| SPA `/login` route firing authenticated API calls before login completes              | memory    | Login page must not call any endpoint requiring a session — causes 401-self-redirect loops                    |
+| Missing salt validation on `u+t+s`                                                    | #112      | Salt is required, must be ≥ 6 hex chars; reject otherwise                                                     |
+
+Full flow: [authentication.md](authentication.md).
+
+## Concurrency
+
+| Trap                                                                                          | Caught by | Rule                                                                                                |
+|-----------------------------------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------------|
+| TOCTOU between `artCache.get()` and concurrent eviction                                       | recurring | `get()` returns content + holds a ref; eviction can't delete an in-flight stream                    |
+| Hoisting prepared statements rebuilt per-request                                              | #130      | Hot-path SQL goes through prepared statements built once at module load                             |
+
+## Navidrome ops
+
+| Trap                                                                                                | Caught by | Rule                                                                                                                              |
+|-----------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------|
+| Transient FS unmount → Navidrome marks rows `missing=1` → federated index shrinks permanently       | #159      | `ND_SCANNER_PURGEMISSING=always` so the next scan re-discovers files; trade-off documented in `docker-compose.yml`                |
+| Using `ND_INITIALADMINPASSWORD` to seed the admin user                                              | memory    | No-op in Navidrome 0.52+. Use `ND_DEVAUTOCREATEADMINPASSWORD`                                                                     |
+| Forgetting to log a warning when local `instance_tracks` count drops materially between syncs       | #159      | Early signal that the music volume disappeared — keep the warning if you touch sync metrics                                       |
+
+## Frontend
+
+| Trap                                                              | Caught by | Rule                                                                                          |
+|-------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------|
+| StarButton updating only after the server roundtrip               | #126      | Optimistic update first; reconcile on response; revert on failure                             |
+| Play button missing on the current track / no pause-on-hover      | #99       | Current track always shows the play control; toggle to pause on click                         |
+
+## Process
+
+| Trap                                                                | Caught by | Rule                                                                                          |
+|---------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------|
+| Broken tests landed on green CI                                     | #116      | CI runs `pnpm verify` (typecheck + test) on every PR                                          |
+| Stacked PRs                                                         | CLAUDE.md | Follow-ups go on the same feature branch — never branch off a draft PR                        |
+| Working without a GitHub issue                                      | AGENTS.md | No issue, no work. Reference the issue in the commit and close on merge                       |

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -35,16 +35,18 @@ The React SPA (served by the hub) or any third-party Subsonic-compatible app. Bo
 
 ### Hub
 
-Fastify + better-sqlite3. Four concerns:
+Fastify + better-sqlite3. Six concerns:
 
-| Concern            | Responsibility                                                                                                     |
-|--------------------|---------------------------------------------------------------------------------------------------------------------|
-| Client API         | Serve the SPA and the Subsonic `/rest/*` surface over a unified library view                                        |
-| Sync + merge       | Pull from local Navidrome (`syncLocal`) and each peer's Navidrome via `/proxy/rest/*`; merge into unified tables; dedup across instances |
-| Stream / art proxy | Route stream and cover-art requests to the correct source (local Navidrome via `/proxy/*`, or peer Navidrome via peer's `/proxy/*`) |
-| Admin              | Owner-only management: sync trigger, peer list, cache stats, instance identity                                      |
+| Concern            | Responsibility                                                                                                                                  |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| Client API         | Serve the SPA and the Subsonic `/rest/*` surface over a unified library view                                                                     |
+| Sync + merge       | Pull from local Navidrome (`syncLocal`) and each peer's Navidrome via `/proxy/rest/*`; merge into unified tables; dedup across instances         |
+| Auto-sync          | `AutoSyncService` polls Navidrome's scan status; when a scan completes, kicks a local sync, then fans out to peers on a `SYNC_INTERVAL_MS` cadence |
+| Stream / art proxy | Route stream and cover-art requests to the correct source (local Navidrome via `/proxy/*`, or peer Navidrome via peer's `/proxy/*`)              |
+| External art       | `/external-art/*` resolves missing artist/release-group artwork from fanart.tv (primary, MBID-keyed) then Last.fm (fallback); results land in `art_cache` |
+| Admin              | Owner-only management under `/admin/*`: sync trigger, peer list, invitation issue/accept, cache stats, instance identity, user management        |
 
-Engineering details (directory layout, service classes, env vars) live in [hub-internals.md](hub-internals.md).
+Engineering details (directory layout, service classes, env vars) live in [hub-internals.md](hub-internals.md). External-art sources: [fanarttv-integration.md](fanarttv-integration.md) and [lastfm-integration.md](lastfm-integration.md).
 
 ### Navidrome
 
@@ -74,18 +76,33 @@ Cross-hub share IDs for albums and artists are resolved entirely locally by each
 
 ## Data model
 
-Two tables per entity — one "raw" (per-instance), one "unified" (deduped across instances):
+Catalog tables come in pairs — one "raw" (per-instance, scraped from Navidrome) and one "unified" (deduped across instances by MBID first, then normalized name):
 
 ```
 instance_artists    ─┐
-instance_albums     ─┼─ merge.ts ─> unified_artists
+instance_albums     ─┼─ merge.ts ─> unified_artists           ◀── unified_artist_sources
 instance_tracks     ─┘              unified_release_groups
-                                    unified_releases
+                                    unified_releases          ◀── unified_release_sources
                                     unified_tracks
                                     track_sources   (keyed by instance_id)
 ```
 
 `track_sources` is the branching point for streaming: each row records which instance (local or peer) holds a copy of a unified track. `instance_id = 'local'` means the bundled Navidrome; a peer's instance ID means that peer's Navidrome. `selectBestSource()` scores sources by format quality → bitrate → local tie-break. Deduplication rules and encoding conventions are documented in [hub-internals.md#federation](hub-internals.md#federation).
+
+The `unified_artist_sources` / `unified_release_sources` join tables let the same unified row be backed by multiple instances at once (used for "which peers own this album" UI and the Subsonic MusicFolders mapping — each peer surfaces as its own folder; see #123).
+
+Supporting tables:
+
+| Table                                  | Purpose                                                                              |
+|----------------------------------------|--------------------------------------------------------------------------------------|
+| `users`                                | Local accounts. AES-256-GCM-encrypted password (reversible for Subsonic `u+t+s`)     |
+| `instances`                            | Peer registry — id, pubkey, proxy URL, version, last-seen, last-sync state           |
+| `invitations`                          | Nonce-tracked signed invitations (consumed once; backs handshake + gossip replay)    |
+| `settings`                             | Singleton-style key/value (instance metadata, JWT secret reference, etc.)            |
+| `playlists`, `playlist_tracks`         | User-owned playlists over unified track IDs                                          |
+| `user_stars`                           | Per-user stars/favorites for artist, album, or track unified IDs                     |
+| `art_cache`                            | LRU-capped on-disk cache for cover art + external (fanart.tv / Last.fm) artwork     |
+| `sync_operations`, `stream_operations` | Operational logs (last sync per peer; recent stream activity for the admin UI)       |
 
 ## Play flow (source selection)
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -1,146 +1,127 @@
 # System architecture
 
-Poutine is a federated music player: a small mesh of independently-operated hubs, each of which bundles an internal Navidrome and exposes a merged view of the whole federation to its users. For the federation protocol contract, see [federation-api.md](federation-api.md). For hub engineering details (conventions, env vars, gotchas), see [hub-internals.md](hub-internals.md).
+Federated music player. Mesh of independently-operated hubs; each bundles a private Navidrome and exposes a merged view of the federation. Protocol: [federation-api.md](federation-api.md). Engineering details: [hub-internals.md](hub-internals.md).
 
-## Deployment model
+## Deployment
 
-Every participant runs their own hub. Each hub is a single Docker Compose stack with two services: the hub itself (Fastify + SQLite, serving the SPA on the same port) and an internal Navidrome (music files, transcoder).
+One Docker Compose stack per participant. Two services: hub (Fastify + SQLite, serves SPA on same port) and internal Navidrome (music files + transcoder, never exposed).
 
 ```
 ┌──────────────────────────────────────────┐
 │  Poutine Hub (one container)             │
-│    ├─ React SPA (static files)           │
-│    ├─ Subsonic API     /rest/*           │
-│    ├─ Proxy tier       /proxy/*          │
-│    ├─ Federation API   /federation/*     │
-│    ├─ Admin API        /admin/*          │
+│    ├─ React SPA (static)                 │
+│    ├─ /rest/*         Subsonic API       │
+│    ├─ /proxy/*        Proxy tier         │
+│    ├─ /federation/*   Federation API     │
+│    ├─ /admin/*        Admin API          │
+│    ├─ /external-art/* fanart.tv/Last.fm  │
 │    └─ SQLite (data + art cache)          │
 ├──────────────────────────────────────────┤
 │  Internal Docker network (not exposed)   │
-│    └─ Navidrome (music files, transcoder)│
+│    └─ Navidrome                          │
 └──────────────────────────────────────────┘
-         ▲                       ▲
-         │ Subsonic (clients)    │ Ed25519-signed federation
-         ▼                       ▼
-    Web / mobile clients     Other hubs (peers)
+       ▲                       ▲
+       │ Subsonic              │ Ed25519-signed
+       ▼                       ▼
+  Web/mobile clients      Peer hubs
 ```
 
-Only the hub's HTTP port is exposed. Navidrome is internal-only. Navidrome credentials come from env vars — they are not stored in the hub database. The SPA and API are served from the same port; there is no separate nginx container in the default deployment.
+Navidrome credentials live in env vars, not the DB. SPA + API on one port.
 
-## Three layers
+## Layers
 
-### Clients
+**Clients** — React SPA or any Subsonic-compatible app. Both speak `/rest/*` via `u+p` or `u+t+s` (MD5 token+salt). SPA logs in at `/admin/login`; see [authentication.md](authentication.md).
 
-The React SPA (served by the hub) or any third-party Subsonic-compatible app. Both speak to `/rest/*` using standard Subsonic auth — `u+p` (plaintext / `enc:<hex>`) or `u+t+s` (MD5 token+salt). The SPA uses `u+t+s` after the user logs in via `/admin/login` (see [authentication.md](authentication.md)).
+**Hub** — Fastify + better-sqlite3:
 
-### Hub
+| Concern        | Responsibility                                                                            |
+|----------------|-------------------------------------------------------------------------------------------|
+| Client API     | SPA + Subsonic `/rest/*` over unified library                                             |
+| Sync + merge   | `syncLocal` from local Navidrome; `/proxy/rest/*` from peers; merge into unified tables   |
+| Auto-sync      | `AutoSyncService`: trigger on Navidrome scan complete; fan out to peers per `SYNC_INTERVAL_MS` |
+| Stream/art     | Route to source's Navidrome via `/proxy/*` (local or peer)                                |
+| External art   | `/external-art/*`: fanart.tv (MBID) → Last.fm fallback → `art_cache`                      |
+| Admin          | `/admin/*` (owner-only): sync, peers, invitations, users, cache, identity                 |
 
-Fastify + better-sqlite3. Six concerns:
+**Navidrome** — private per hub. Driven entirely through Subsonic (`getArtists`, `getAlbum`, `stream`, `getCoverArt`, `getScanStatus`, `startScan`). Its native `/api/*` is unused.
 
-| Concern            | Responsibility                                                                                                                                  |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| Client API         | Serve the SPA and the Subsonic `/rest/*` surface over a unified library view                                                                     |
-| Sync + merge       | Pull from local Navidrome (`syncLocal`) and each peer's Navidrome via `/proxy/rest/*`; merge into unified tables; dedup across instances         |
-| Auto-sync          | `AutoSyncService` polls Navidrome's scan status; when a scan completes, kicks a local sync, then fans out to peers on a `SYNC_INTERVAL_MS` cadence |
-| Stream / art proxy | Route stream and cover-art requests to the correct source (local Navidrome via `/proxy/*`, or peer Navidrome via peer's `/proxy/*`)              |
-| External art       | `/external-art/*` resolves missing artist/release-group artwork from fanart.tv (primary, MBID-keyed) then Last.fm (fallback); results land in `art_cache` |
-| Admin              | Owner-only management under `/admin/*`: sync trigger, peer list, invitation issue/accept, cache stats, instance identity, user management        |
+## Federation
 
-Engineering details (directory layout, service classes, env vars) live in [hub-internals.md](hub-internals.md). External-art sources: [fanarttv-integration.md](fanarttv-integration.md) and [lastfm-integration.md](lastfm-integration.md).
+Peers stored in `instances` (DB-authoritative since v0.5.0 / federation v5), authenticated by Ed25519 pubkey. Every `/federation/*` and `/proxy/*` request is signed.
 
-### Navidrome
+- No central registry; small trusted networks (4–12).
+- Stable instance ID + long-lived Ed25519 keypair per hub.
+- Admission: one signed invitation (issue → accept → gossip propagates).
 
-Per-hub private music server. Bundled in Docker Compose, reachable only over the internal network. The hub drives it entirely via the Subsonic API (`getArtists`, `getAlbum`, `stream`, `getCoverArt`, `getScanStatus`, `startScan`). Navidrome's native `/api/*` REST API is not used.
+| Route                    | Purpose                                                                |
+|--------------------------|------------------------------------------------------------------------|
+| `/federation/handshake`  | Signed-invitation peer admission                                       |
+| `/federation/peers`      | Gossip — verify embedded invitation against named inviter's pubkey     |
+| `/federation/stream/:id` | Cross-peer audio stream                                                |
+| `/proxy/rest/*`          | Authenticated proxy to local Navidrome (clients and peers both use it) |
 
-## Federation model
-
-Hubs are peers stored in each other's `instances` table (DB-authoritative since v0.5.0 / federation v5), authenticated by Ed25519 public keys. Every `/federation/*` (and `/proxy/*`) request is signed by the sender. Peer-to-peer means:
-
-- No central registry or directory.
-- Small, trusted networks (4–12 participants).
-- Each hub has a stable instance ID and a long-lived Ed25519 keypair.
-- Adding a peer takes one signed invitation: the inviter issues, the invitee accepts, and gossip during the next sync round propagates the new member to the rest of the cluster.
-
-The `/federation/*` surface carries peer identity, the invitation handshake, and gossip in v5. Content (audio streams, cover art) and catalog metadata travel through `/proxy/*`:
-
-| Route                       | Purpose                                                                                                                              |
-|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `/federation/handshake`     | Signed-invitation peer admission (v5)                                                                                                |
-| `/federation/peers`         | Gossip — receivers verify the embedded signed invitation against the named inviter's pubkey                                          |
-| `/federation/stream/:id`    | Cross-peer audio stream                                                                                                              |
-| `/proxy/rest/*`             | Authenticated transparent proxy to local Navidrome — used by both local clients and peers for catalog sync, art, and streaming      |
-
-Contract details (headers, signing payload, error codes): [federation-api.md](federation-api.md). `/proxy/*` auth modes: [hub-internals.md#proxy](hub-internals.md#proxy).
-
-Cross-hub share IDs for albums and artists are resolved entirely locally by each hub against its synced `instance_*` tables — no federation RPC. See [hub-internals.md#share-ids](hub-internals.md#share-ids).
+Contract: [federation-api.md](federation-api.md). Share IDs resolve locally against synced `instance_*` tables — no RPC. See [hub-internals.md#share-ids](hub-internals.md#share-ids).
 
 ## Data model
 
-Catalog tables come in pairs — one "raw" (per-instance, scraped from Navidrome) and one "unified" (deduped across instances by MBID first, then normalized name):
+Catalog tables come in pairs: `instance_*` (raw per-instance) and `unified_*` (deduped by MBID, then normalized name).
 
 ```
-instance_artists    ─┐
-instance_albums     ─┼─ merge.ts ─> unified_artists           ◀── unified_artist_sources
-instance_tracks     ─┘              unified_release_groups
-                                    unified_releases          ◀── unified_release_sources
-                                    unified_tracks
-                                    track_sources   (keyed by instance_id)
+instance_artists  ─┐
+instance_albums   ─┼─ merge.ts ─> unified_artists         ◀── unified_artist_sources
+instance_tracks   ─┘              unified_release_groups
+                                  unified_releases        ◀── unified_release_sources
+                                  unified_tracks
+                                  track_sources           (keyed by instance_id)
 ```
 
-`track_sources` is the branching point for streaming: each row records which instance (local or peer) holds a copy of a unified track. `instance_id = 'local'` means the bundled Navidrome; a peer's instance ID means that peer's Navidrome. `selectBestSource()` scores sources by format quality → bitrate → local tie-break. Deduplication rules and encoding conventions are documented in [hub-internals.md#federation](hub-internals.md#federation).
+`track_sources` is the streaming branch point. `selectBestSource()` ranks by format → bitrate → local tie-break. Merge rules: [hub-internals.md#federation](hub-internals.md#federation).
 
-The `unified_artist_sources` / `unified_release_sources` join tables let the same unified row be backed by multiple instances at once (used for "which peers own this album" UI and the Subsonic MusicFolders mapping — each peer surfaces as its own folder; see #123).
+`unified_*_sources` join tables back the "which peers own this" UI and the Subsonic MusicFolders mapping (one folder per peer).
 
-Supporting tables:
+| Table                                  | Purpose                                                         |
+|----------------------------------------|------------------------------------------------------------------|
+| `users`                                | Local accounts; AES-256-GCM password (reversible for `u+t+s`)    |
+| `instances`                            | Peer registry: id, pubkey, proxy URL, version, last-seen/sync    |
+| `invitations`                          | Nonce-tracked signed invitations (consumed once)                 |
+| `settings`                             | Singleton key/value (instance metadata, JWT secret ref)          |
+| `playlists`, `playlist_tracks`         | User playlists over unified track IDs                            |
+| `user_stars`                           | Per-user stars (artist/album/track unified IDs)                  |
+| `art_cache`                            | LRU on-disk cache for cover art + external artwork               |
+| `sync_operations`, `stream_operations` | Per-peer sync state + recent stream activity                     |
 
-| Table                                  | Purpose                                                                              |
-|----------------------------------------|--------------------------------------------------------------------------------------|
-| `users`                                | Local accounts. AES-256-GCM-encrypted password (reversible for Subsonic `u+t+s`)     |
-| `instances`                            | Peer registry — id, pubkey, proxy URL, version, last-seen, last-sync state           |
-| `invitations`                          | Nonce-tracked signed invitations (consumed once; backs handshake + gossip replay)    |
-| `settings`                             | Singleton-style key/value (instance metadata, JWT secret reference, etc.)            |
-| `playlists`, `playlist_tracks`         | User-owned playlists over unified track IDs                                          |
-| `user_stars`                           | Per-user stars/favorites for artist, album, or track unified IDs                     |
-| `art_cache`                            | LRU-capped on-disk cache for cover art + external (fanart.tv / Last.fm) artwork     |
-| `sync_operations`, `stream_operations` | Operational logs (last sync per peer; recent stream activity for the admin UI)       |
-
-## Play flow (source selection)
+## Play flow
 
 ```
-1. Client POSTs play for unified track ID <uuid>
-2. Hub looks up track_sources for the unified track
-3. selectBestSource picks the winning source
-4. If source.instance_id === 'local':
-     proxy /proxy/rest/stream from the bundled Navidrome (JWT auth)
-   If source.instance_id === <peer-id>:
-     sign & GET /proxy/rest/stream on the chosen peer's proxy_url (Ed25519 auth)
-5. Response is piped to the client (no buffering in the hub)
+1. Client requests unified track ID
+2. Hub reads track_sources, selectBestSource picks winner
+3. Local source  → /proxy/rest/stream on local Navidrome (JWT auth)
+   Peer source   → signed GET /proxy/rest/stream on peer (Ed25519)
+4. Response piped to client (no hub buffering)
 ```
 
-Transcoding happens on whichever Navidrome owns the bytes, never on the hub.
+Transcoding happens on the Navidrome that owns the bytes.
 
-## Auth model
+## Auth
 
-| Concern         | Approach                                                             |
-|-----------------|----------------------------------------------------------------------|
-| User passwords  | AES-256-GCM (reversible — needed for Subsonic `u+t+s`). Key on disk. |
-| Session tokens  | JWT for `/admin/*` only: 15 min access + 7 d refresh                 |
-| Subsonic auth   | `u+p` or `u+t+s` (MD5 token+salt). SPA + 3rd-party clients use either |
-| Peer auth       | Ed25519 signature on every `/federation/*` and `/proxy/*` request    |
-| Proxy auth      | Unified: Ed25519 (peers) → JWT (admin) → Subsonic `u+p`/`u+t+s`     |
-| Navidrome auth  | Env-var creds, never in DB; internal network only                    |
-| Transport       | HTTPS required in prod for peer-to-peer reachability                 |
+| Concern        | Approach                                                          |
+|----------------|-------------------------------------------------------------------|
+| User passwords | AES-256-GCM, on-disk key                                          |
+| Session tokens | JWT for `/admin/*`: 15 min access + 7 d refresh                   |
+| Subsonic       | `u+p` or `u+t+s`                                                  |
+| Peer           | Ed25519 signature on every `/federation/*` and `/proxy/*`         |
+| Proxy          | Ed25519 (peers) → JWT (admin) → Subsonic `u+p`/`u+t+s`           |
+| Navidrome      | Env-var creds, internal network only                              |
+| Transport      | HTTPS required in prod                                            |
 
-Flow details: [authentication.md](authentication.md). `/proxy/*` auth detail: [hub-internals.md#proxy](hub-internals.md#proxy).
+Detail: [authentication.md](authentication.md), [hub-internals.md#proxy](hub-internals.md#proxy).
 
 ## Scale envelope
 
-Small by design. The merge algorithm, fan-out sync, and unified SQLite tables are tuned for the 4–12 hub range.
-
-| Dimension                  | Target                                             |
-|----------------------------|----------------------------------------------------|
-| Peer hubs                  | 4–12                                               |
-| Concurrent users per hub   | ~20–50                                             |
-| Per-hub library            | ~50k tracks                                        |
-| Merged library             | ~200k–600k tracks                                  |
-| Sync cadence               | On Navidrome scan completion (auto) or on demand  |
+| Dimension         | Target                                  |
+|-------------------|------------------------------------------|
+| Peer hubs         | 4–12                                    |
+| Users per hub     | ~20–50                                  |
+| Per-hub library   | ~50k tracks                             |
+| Merged library    | ~200k–600k tracks                       |
+| Sync cadence      | On Navidrome scan complete or on demand |


### PR DESCRIPTION
Closes #171.

## Summary
- Refresh `docs/system-architecture.md` to reflect what the hub actually does today: `AutoSyncService`, the external-art (fanart.tv → Last.fm) tier, the `unified_*_sources` join tables that back the MusicFolders → peers mapping (#123), and the supporting tables (`users`, `instances`, `invitations`, `settings`, `playlists`, `user_stars`, `art_cache`, `sync_operations`, `stream_operations`).
- Fix broken cross-reference in `docs/hub-internals.md` (`02-system-architecture.md` → `system-architecture.md`).

## Test plan
- [ ] Render the doc and confirm all cross-links resolve
- [ ] Spot-check that the supporting-tables list matches `hub/src/db/schema.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)