### PR TITLE
feat(subsonic): implement getOpenSubsonicExtensions (#236)

### DIFF
--- a/docs/opensubsonic.md
+++ b/docs/opensubsonic.md
@@ -56,7 +56,7 @@ All endpoints support both GET and POST, with and without the `.view` suffix (e.
 |-----------------------------|-----------------|------------------------------|
 | `ping`                      | Implemented     |                              |
 | `getLicense`                | Implemented     | Always returns `valid: true` |
-| `getOpenSubsonicExtensions` | NOT IMPLEMENTED |                              |
+| `getOpenSubsonicExtensions` | Implemented     | **Unauthenticated** (spec: callable before login for capability negotiation). Returns the static `OPENSUBSONIC_EXTENSIONS` list in `subsonic-response.ts`. Currently advertises only `transcodeOffset` (v1) — `timeOffset` on transcoded streams (#109). `formPost` is intentionally NOT advertised: POST is accepted but no `x-www-form-urlencoded` body parser is registered, so params are read from the query string only. (#236) |
 
 ### Browsing
 

--- a/hub/src/routes/subsonic-response.ts
+++ b/hub/src/routes/subsonic-response.ts
@@ -5,6 +5,28 @@ export const SUBSONIC_VERSION = "1.16.1";
 export const SERVER_TYPE = "poutine";
 export const SERVER_VERSION = APP_VERSION;
 
+/**
+ * OpenSubsonic optional extensions this server implements, returned by
+ * `getOpenSubsonicExtensions` for client capability negotiation. Each entry is
+ * `{ name, versions }` per the spec. Clients route around anything absent, so
+ * only list extensions that are FULLY supported — advertising an unsupported
+ * one makes clients enable features that then fail.
+ *
+ * - `transcodeOffset` (v1): `timeOffset` is honored on transcoded streams
+ *   (#109). Not applied to raw passthrough — see docs/pitfalls.md (#204) — but
+ *   the extension only promises offset support for transcoded media.
+ *
+ * NOT advertised (deliberately):
+ * - `formPost`: POST is accepted on every endpoint, but params are read from
+ *   the query string only — no `application/x-www-form-urlencoded` body parser
+ *   is registered, so a form-body POST would auth-fail. Tracked for follow-up.
+ * - `songLyrics`, `apiKeyAuthentication`: endpoints not implemented yet.
+ */
+export const OPENSUBSONIC_EXTENSIONS: ReadonlyArray<{
+  name: string;
+  versions: number[];
+}> = [{ name: "transcodeOffset", versions: [1] }];
+
 export type Format = "json" | "xml";
 
 // Subsonic spec: default response format is XML when `f=` is omitted.

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -8,6 +8,7 @@ import {
   sendBinaryError,
   encodeId,
   decodeId,
+  OPENSUBSONIC_EXTENSIONS,
 } from "./subsonic-response.js";
 import { decodeCoverArtId } from "../library/cover-art.js";
 import { isAllowedExternalArtUrl } from "./external-art.js";
@@ -270,6 +271,20 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
     app.post(`${path}.view`, { preHandler }, handler);
   }
 
+  /**
+   * Register an UNAUTHENTICATED handler (GET+POST, with/without `.view`).
+   * Only for endpoints the OpenSubsonic spec marks as callable without
+   * credentials — currently just `getOpenSubsonicExtensions`, which clients
+   * probe before login to negotiate capabilities. Do not use this for anything
+   * that reads user state or library data.
+   */
+  function publicRoute(path: string, handler: RouteHandlerMethod): void {
+    app.get(path, handler);
+    app.get(`${path}.view`, handler);
+    app.post(path, handler);
+    app.post(`${path}.view`, handler);
+  }
+
   // ── Hoisted prepared statements for star/unstar/getStarred2 (#130) ──────────
   // Prepared once at plugin init rather than per-request to avoid allocation
   // churn on hot endpoints.
@@ -356,6 +371,21 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
     const q = request.query as Record<string, string>;
     sendSubsonicOk(reply, q, {
       license: { valid: true, email: "", licenseExpires: "" },
+    });
+  });
+
+  // ── getOpenSubsonicExtensions ─────────────────────────────────────────────
+  // Capability negotiation. Per spec this endpoint is callable WITHOUT auth so
+  // clients can feature-detect before login — hence publicRoute. Returns the
+  // static OPENSUBSONIC_EXTENSIONS list (source of truth in subsonic-response).
+
+  publicRoute("/getOpenSubsonicExtensions", async (request, reply) => {
+    const q = request.query as Record<string, string>;
+    sendSubsonicOk(reply, q, {
+      openSubsonicExtensions: OPENSUBSONIC_EXTENSIONS.map((e) => ({
+        name: e.name,
+        versions: e.versions,
+      })),
     });
   });
 

--- a/hub/test/subsonic-routes.test.ts
+++ b/hub/test/subsonic-routes.test.ts
@@ -243,6 +243,51 @@ describe("Subsonic routes — endpoints", () => {
     expect(body["subsonic-response"].license.valid).toBe(true);
   });
 
+  it("getOpenSubsonicExtensions → lists transcodeOffset (authed JSON)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getOpenSubsonicExtensions?u=tester&p=secret&f=json",
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body["subsonic-response"].status).toBe("ok");
+    const exts = body["subsonic-response"].openSubsonicExtensions as Array<{
+      name: string;
+      versions: number[];
+    }>;
+    expect(Array.isArray(exts)).toBe(true);
+    const offset = exts.find((e) => e.name === "transcodeOffset");
+    expect(offset).toBeDefined();
+    expect(offset?.versions).toEqual([1]);
+    // formPost is deliberately NOT advertised (no form-body parser).
+    expect(exts.find((e) => e.name === "formPost")).toBeUndefined();
+  });
+
+  it("getOpenSubsonicExtensions → callable WITHOUT credentials (spec)", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getOpenSubsonicExtensions?f=json",
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body["subsonic-response"].status).toBe("ok");
+    expect(
+      (body["subsonic-response"].openSubsonicExtensions as unknown[]).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("getOpenSubsonicExtensions → XML nests <versions> under named extension", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/getOpenSubsonicExtensions.view?f=xml",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("xml");
+    expect(res.body).toContain(
+      '<openSubsonicExtensions name="transcodeOffset"><versions>1</versions></openSubsonicExtensions>',
+    );
+  });
+
   it("getMusicFolders → one folder per known instance", async () => {
     const res = await app.inject({
       method: "GET",

--- a/test/federation/subsonic-compat/test_compat.py
+++ b/test/federation/subsonic-compat/test_compat.py
@@ -279,6 +279,38 @@ def test_opensubsonic_envelope_fields(conn):
     assert "serverVersion" in env
 
 
+def test_get_opensubsonic_extensions(conn):
+    """#236: capability negotiation endpoint. Spec marks it callable WITHOUT
+    auth so clients (Symfonium, Feishin, Amperfy) can feature-detect pre-login.
+    Must list transcodeOffset and must NOT list formPost (no form-body parser)."""
+    import json
+    import urllib.request
+
+    base = f"{conn._baseUrl}:{conn._port}/rest/getOpenSubsonicExtensions"
+
+    # No credentials at all — still returns ok.
+    env = json.loads(
+        urllib.request.urlopen(f"{base}?v=1.16.1&c=poutine-compat&f=json").read()
+    )["subsonic-response"]
+    assert env["status"] == "ok"
+    exts = env["openSubsonicExtensions"]
+    if isinstance(exts, dict):
+        exts = [exts]
+    names = {e["name"] for e in exts}
+    assert "transcodeOffset" in names
+    assert "formPost" not in names
+    offset = next(e for e in exts if e["name"] == "transcodeOffset")
+    versions = offset["versions"]
+    if isinstance(versions, int):
+        versions = [versions]
+    assert 1 in versions
+
+    # XML form nests <versions> under the named extension element.
+    xml = urllib.request.urlopen(f"{base}.view?v=1.16.1&c=poutine-compat&f=xml").read()
+    assert b'name="transcodeOffset"' in xml
+    assert b"<versions>1</versions>" in xml
+
+
 def test_view_suffix_equivalence(conn):
     import json, urllib.request
     qs = f"u={conn._username}&p={conn._rawPass}&v=1.16.1&c=poutine-compat&f=json"


### PR DESCRIPTION
## What

Implements `getOpenSubsonicExtensions` (#236) — the OpenSubsonic capability-negotiation endpoint. Until now Poutine set `openSubsonic: true` but advertised no extension list, so clients (Symfonium, Feishin, Amperfy, DSub) fell back to assuming stock Subsonic 1.16.1 and routed around features we actually have.

## Key decisions

- **Unauthenticated.** Per the OpenSubsonic spec this endpoint is callable *before* login for feature detection. It registers via a new `publicRoute` helper instead of the auth-gated `route` helper. (`publicRoute` is intentionally narrow — only for spec-public endpoints; documented inline.)
- **Advertises only `transcodeOffset` (v1)** — `timeOffset` on transcoded streams (#109). Honest over aspirational: clients enable features off this list, so listing an unsupported one breaks them.
- **`formPost` deliberately NOT advertised.** POST is accepted on every endpoint, but there's **no** `x-www-form-urlencoded` body parser registered (`@fastify/formbody` absent; the only `addContentTypeParser` calls are federation-JSON and DLNA-SOAP). Auth + handlers read `request.query` only, so a form-body POST would auth-fail with code 10. Left as a documented follow-up.
- Source of truth is `OPENSUBSONIC_EXTENSIONS` in `subsonic-response.ts`.

## Tests

- **Unit** (`subsonic-routes.test.ts`): authed JSON lists `transcodeOffset` / omits `formPost`; callable with no credentials; XML nests `<versions>1</versions>` under the named extension.
- **subsonic-compat** (`test_compat.py`): no-cred call returns ok, `transcodeOffset` present, `formPost` absent, XML form correct.
- `pnpm verify` ✅ · `pnpm lint` clean ✅ · `pnpm test:federation` 84 passed ✅

## Scope note

Based on `main`, which does **not** include the #197 play-counts work — so `scrobble` is still a stub here and `test_scrobble_stub` is left as-is (correct for this base). Survey-doc reconciliation for #197 is handled on the `feature/197-play-counts` branch, not in this PR.

## Out of scope / follow-ups

- `getNowPlaying` (now-playing from the scrobble signal) → #237
- `formPost` (needs a form-body parser) → noted in code; no issue yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
