### PR TITLE
Artist cover-art thumbnails in search + uniform getCoverArt proxying (#211)

### DIFF
--- a/frontend/src/lib/subsonic.ts
+++ b/frontend/src/lib/subsonic.ts
@@ -422,6 +422,7 @@ export async function search3(query: string): Promise<SubsonicSearchResults> {
       id: a.id,
       name: a.name,
       albumCount: a.albumCount ?? 0,
+      coverArt: a.coverArt,
       starred: a.starred,
     })),
     albums: (r.album ?? []).map(parseAlbum),

--- a/frontend/src/lib/subsonic.ts
+++ b/frontend/src/lib/subsonic.ts
@@ -560,10 +560,10 @@ export function streamUrl(
 }
 
 export function artUrl(coverArtId: string, size?: number): string | null {
-  // Last.fm and other absolute URLs are returned as-is.
-  if (coverArtId.startsWith("http://") || coverArtId.startsWith("https://")) {
-    return coverArtId;
-  }
+  // Everything routes through getCoverArt — including absolute fanart.tv /
+  // Last.fm URLs. The hub fetches and caches external art behind an SSRF
+  // allowlist, so local (fanart-URL) and peer (encoded-id) art follow the
+  // same proxied path rather than the browser hitting third parties directly.
   const params = authParamsWithSalt(ART_SALT);
   if (!params) return null;
   params.set("id", coverArtId);

--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { SearchPage } from "./SearchPage";
+import type {
+  SubsonicAlbum,
+  SubsonicArtist,
+  SubsonicSearchResults,
+} from "@/lib/subsonic";
+
+vi.mock("@/lib/subsonic", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/subsonic")>("@/lib/subsonic");
+  return {
+    ...actual,
+    search3: vi.fn(),
+    artUrl: (id: string, size?: number) =>
+      `/art/${id}${size ? `?size=${size}` : ""}`,
+  };
+});
+
+import { search3 } from "@/lib/subsonic";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function album(overrides: Partial<SubsonicAlbum>): SubsonicAlbum {
+  return {
+    id: "al1",
+    name: "Kid A",
+    artist: "Radiohead",
+    artistId: "ar1",
+    songCount: 11,
+    ...overrides,
+  };
+}
+
+function artist(overrides: Partial<SubsonicArtist>): SubsonicArtist {
+  return {
+    id: "ar1",
+    name: "Radiohead",
+    albumCount: 9,
+    ...overrides,
+  };
+}
+
+const EMPTY: SubsonicSearchResults = { artists: [], albums: [], songs: [] };
+
+function typeQuery(text: string) {
+  fireEvent.change(screen.getByPlaceholderText(/search for artists/i), {
+    target: { value: text },
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(search3).mockReset();
+});
+
+describe("SearchPage album cover art (#211)", () => {
+  it("renders a cover-art thumbnail for albums that have one", async () => {
+    vi.mocked(search3).mockResolvedValue({
+      ...EMPTY,
+      albums: [album({ coverArt: "al1" })],
+    });
+
+    renderPage();
+    typeQuery("kid a");
+
+    const cover = await screen.findByRole("img", { name: "Kid A" });
+    expect(cover.getAttribute("src")).toBe("/art/al1?size=80");
+  });
+
+  it("falls back to the placeholder icon when an album has no cover art", async () => {
+    vi.mocked(search3).mockResolvedValue({
+      ...EMPTY,
+      albums: [album({ id: "al2", name: "No Art", coverArt: undefined })],
+    });
+
+    renderPage();
+    typeQuery("no art");
+
+    expect(
+      await screen.findByText("No Art", {}, { timeout: 3000 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "No Art" })).toBeNull();
+  });
+});
+
+describe("SearchPage artist cover art (#211)", () => {
+  it("renders a cover-art thumbnail for artists that have one", async () => {
+    vi.mocked(search3).mockResolvedValue({
+      ...EMPTY,
+      artists: [artist({ coverArt: "ar1" })],
+    });
+
+    renderPage();
+    typeQuery("radiohead");
+
+    const cover = await screen.findByRole("img", { name: "Radiohead" });
+    expect(cover.getAttribute("src")).toBe("/art/ar1?size=80");
+  });
+
+  it("falls back to the initials placeholder when an artist has no cover art", async () => {
+    vi.mocked(search3).mockResolvedValue({
+      ...EMPTY,
+      artists: [artist({ id: "ar2", name: "No Art", coverArt: undefined })],
+    });
+
+    renderPage();
+    typeQuery("no art");
+
+    expect(
+      await screen.findByText("No Art", {}, { timeout: 3000 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "No Art" })).toBeNull();
+  });
+});

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { search3 } from "@/lib/subsonic";
+import { search3, artUrl } from "@/lib/subsonic";
 import type { SubsonicSong } from "@/lib/subsonic";
 import { usePlayer } from "@/stores/player";
 import { formatDuration } from "@/lib/format";
@@ -105,12 +105,21 @@ export function SearchPage() {
                     className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-surface-hover transition-colors text-left cursor-pointer"
                   >
                     <div
-                      className="w-10 h-10 rounded-full flex items-center justify-center shrink-0"
+                      className="w-10 h-10 rounded-full flex items-center justify-center shrink-0 overflow-hidden"
                       style={{ backgroundColor: hashColor(artist.name) }}
                     >
-                      <span className="text-xs font-semibold text-white/70">
-                        {initials(artist.name)}
-                      </span>
+                      {artist.coverArt ? (
+                        <img
+                          src={artUrl(artist.coverArt, 80) ?? undefined}
+                          alt={artist.name}
+                          className="w-full h-full object-cover"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <span className="text-xs font-semibold text-white/70">
+                          {initials(artist.name)}
+                        </span>
+                      )}
                     </div>
                     <div className="min-w-0">
                       <p className="text-sm text-text-primary truncate">{artist.name}</p>
@@ -139,10 +148,19 @@ export function SearchPage() {
                     className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-surface-hover transition-colors text-left cursor-pointer"
                   >
                     <div
-                      className="w-10 h-10 rounded-md flex items-center justify-center shrink-0"
+                      className="w-10 h-10 rounded-md flex items-center justify-center shrink-0 overflow-hidden"
                       style={{ backgroundColor: hashColor(album.name) }}
                     >
-                      <Disc className="w-5 h-5 text-white/30" />
+                      {album.coverArt ? (
+                        <img
+                          src={artUrl(album.coverArt, 80) ?? undefined}
+                          alt={album.name}
+                          className="w-full h-full object-cover"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <Disc className="w-5 h-5 text-white/30" />
+                      )}
                     </div>
                     <div className="min-w-0">
                       <p className="text-sm text-text-primary truncate">{album.name}</p>

--- a/hub/src/routes/external-art.ts
+++ b/hub/src/routes/external-art.ts
@@ -11,6 +11,8 @@
 const ALLOWED_HOSTNAMES: readonly string[] = [
   "fanart.tv",
   "assets.fanart.tv",
+  // Last.fm artist-image CDN (fallback source for artists without an MBID).
+  "lastfm.freetls.fastly.net",
 ];
 
 const ALLOWED_SUFFIXES: readonly string[] = [".fanart.tv"];

--- a/hub/src/routes/subsonic.ts
+++ b/hub/src/routes/subsonic.ts
@@ -1106,7 +1106,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
 
     const artists = app.db
       .prepare(
-        `SELECT ua.id, ua.name, COUNT(urg.id) AS albumCount
+        `SELECT ua.id, ua.name, ua.image_url, COUNT(urg.id) AS albumCount
         FROM unified_artists ua
         LEFT JOIN unified_release_groups urg ON urg.artist_id = ua.id
         WHERE ua.name_normalized LIKE ?
@@ -1213,6 +1213,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
       id: encodeId("ar", a.id),
       name: a.name,
       albumCount: a.albumCount,
+      coverArt: a.image_url ?? undefined,
     }));
     const builtAlbums = albums.map(buildAlbum);
     const builtSongs = songs.map(buildSong);

--- a/hub/test/external-art.test.ts
+++ b/hub/test/external-art.test.ts
@@ -20,9 +20,15 @@ describe("isAllowedExternalArtUrl", () => {
     expect(isAllowedExternalArtUrl("http://assets.fanart.tv/x.jpg")).toBe(false);
   });
 
+  it("allows the Last.fm image CDN", () => {
+    expect(
+      isAllowedExternalArtUrl("https://lastfm.freetls.fastly.net/i/u/x.jpg"),
+    ).toBe(true);
+  });
+
   it("rejects unrelated hostnames", () => {
     expect(isAllowedExternalArtUrl("https://evil.example.com/x.jpg")).toBe(false);
-    expect(isAllowedExternalArtUrl("https://lastfm.freetls.fastly.net/x.jpg")).toBe(false);
+    expect(isAllowedExternalArtUrl("https://other.fastly.net/x.jpg")).toBe(false);
   });
 
   it("rejects hostnames that merely contain 'fanart.tv' as a substring", () => {

--- a/hub/test/getcoverart-external.test.ts
+++ b/hub/test/getcoverart-external.test.ts
@@ -106,6 +106,28 @@ describe("/rest/getCoverArt external URL passthrough", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    "https://localhost/x.jpg",
+    "https://127.0.0.1/x.jpg",
+    "https://169.254.169.254/latest/meta-data/", // cloud metadata SSRF target
+    "https://navidrome:4533/x.jpg", // internal compose service
+    "https://10.0.0.5/x.jpg",
+  ])("refuses to proxy internal/LAN target %s (400, no fetch)", async (target) => {
+    // Raw-URL form (3rd-party client echoing back a coverArt value)…
+    const raw = `/rest/getCoverArt?u=tester&p=secret&f=json&id=${encodeURIComponent(target)}`;
+    const rawRes = await app.inject({ method: "GET", url: raw });
+    expect(rawRes.statusCode).toBe(400);
+
+    // …and the encoded `local:` form a malicious peer could federate.
+    const encRes = await app.inject({
+      method: "GET",
+      url: artUrl(encodeCoverArtId("local", target)),
+    });
+    expect(encRes.statusCode).toBe(400);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects http:// (https only) with 400 and never fetches", async () => {
     const id = encodeCoverArtId("local", "http://assets.fanart.tv/x.jpg");
     const res = await app.inject({ method: "GET", url: artUrl(id) });

--- a/hub/test/subsonic-routes.test.ts
+++ b/hub/test/subsonic-routes.test.ts
@@ -615,6 +615,27 @@ describe("Subsonic routes — endpoints", () => {
     expect(byMbid.json()["subsonic-response"].searchResult3.artist).toHaveLength(1);
   });
 
+  it("search3 returns coverArt for an artist with an image_url", async () => {
+    app.db
+      .prepare(
+        "INSERT INTO unified_artists (id, name, name_normalized, image_url) VALUES (?, ?, ?, ?)",
+      )
+      .run(
+        "artist-art-1",
+        "Cover Artist",
+        "cover artist",
+        "https://example.com/art.jpg",
+      );
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/search3?u=tester&p=secret&f=json&query=cover artist",
+    });
+    const artist = res.json()["subsonic-response"].searchResult3.artist[0];
+    expect(artist.name).toBe("Cover Artist");
+    expect(artist.coverArt).toBe("https://example.com/art.jpg");
+  });
+
   it("search3 matches album by internal id and MusicBrainz id", async () => {
     app.db
       .prepare(


### PR DESCRIPTION
## Summary

Extends the album-cover-art-in-search work (#211) to artists, and fixes an inconsistency discovered while testing: local artist images bypassed `getCoverArt` while peer images didn't.

## Changes

**Artist thumbnails in search**
- `hub` `search3` now selects `unified_artists.image_url` and emits it as the artist `coverArt`.
- Frontend `search3` mapping now carries artist `coverArt` (it was silently dropped, unlike `getStarred2`).
- `SearchPage` renders the artist thumbnail with an initials fallback, mirroring the album treatment.

**Uniform cover-art proxying**
- `artUrl()` previously returned absolute fanart.tv / Last.fm URLs as-is, so the browser fetched them directly. Local artists store a fanart.tv URL → bypassed `getCoverArt` and the hub's server-side cache; peer artists (encoded `instanceId:coverArtId`) went through it. Now **all** art ids — including absolute URLs — route through `/rest/getCoverArt`, so local and peer art share one proxied, cached, SSRF-guarded path.
- `getCoverArt`'s external-fetch allowlist intentionally excluded Last.fm (the artist-image fallback), which loaded direct-to-browser. Now that it proxies too, added `lastfm.freetls.fastly.net` to the allowlist.

## Testing

- `pnpm verify` ✅ (hub typecheck + lint:boundary + unit)
- Frontend build/typecheck ✅
- `pnpm test:federation` (Python subsonic-compat, hub-a/b/c) ✅ — 84 passed, incl. `test_search3` and `test_get_cover_art`
- New tests:
  - hub route test asserting artist `coverArt` is returned by `search3`
  - frontend tests for artist thumbnail + initials fallback
  - allowlist test for the Last.fm CDN host
  - **route-level SSRF tests** confirming `getCoverArt` refuses internal/LAN targets (`localhost`, `127.0.0.1`, `169.254.169.254`, compose service names, private IPs) in both raw-URL and encoded-`local:` forms, never issuing a fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)