### PR TITLE
Download tracks and albums (#35)

### DIFF
--- a/docs/opensubsonic.md
+++ b/docs/opensubsonic.md
@@ -115,7 +115,7 @@ All endpoints support both GET and POST, with and without the `.view` suffix (e.
 | Endpoint            | Status          | Notes                                                                          |
 |---------------------|-----------------|--------------------------------------------------------------------------------|
 | `stream`            | Implemented     | Supports `format`, `maxBitRate`, and `timeOffset`; selects best source across federated peers. HTTP `Range` forwarded for raw passthrough (206 + `Content-Range`); dropped when transcoding (#97). Frontend uses `timeOffset` to seek inside transcoded streams (#109) |
-| `download`          | Implemented     | Alias for `stream`; clients use them interchangeably                           |
+| `download`          | Implemented     | Original bytes, never transcoded (`format`/`maxBitRate` ignored per spec), `Content-Disposition: attachment`. Track id (`t…`) → single file named `Artist - Title.ext`; album id (`al…`) → streaming ZIP (stored entries, `NN - Title.ext`) of the best release's tracks (#35). Peer-sourced tracks proxied raw via `/federation/stream` |
 | `hls`               | NOT IMPLEMENTED |                                                                                |
 | `getCaptions`       | NOT IMPLEMENTED |                                                                                |
 | `getCoverArt`       | Implemented     | Disk-cached with LRU eviction; ID format `{instanceId}:{coverArtId}`           |

--- a/frontend/src/lib/subsonic.test.ts
+++ b/frontend/src/lib/subsonic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { isAuthErrorCode, getArtists, SubsonicError } from "./subsonic";
+import { isAuthErrorCode, getArtists, downloadUrl, SubsonicError } from "./subsonic";
 import { setSubsonicCreds } from "./api";
 
 // Subsonic auth-related error codes per OpenSubsonic spec. Codes 10/40/41/42/43/44
@@ -109,5 +109,29 @@ describe("subsonicFetch — redirect on auth error codes", () => {
     });
     await expect(getArtists()).rejects.toBeInstanceOf(SubsonicError);
     expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── downloadUrl (#35) ────────────────────────────────────────────────────────
+
+describe("downloadUrl", () => {
+  it("builds an authed /rest/download URL with no transcode params", () => {
+    setSubsonicCreds({ username: "u", password: "p" });
+    const url = downloadUrl("t123");
+    expect(url).not.toBeNull();
+    expect(url!.startsWith("/rest/download?")).toBe(true);
+    const params = new URLSearchParams(url!.split("?")[1]);
+    expect(params.get("id")).toBe("t123");
+    expect(params.get("u")).toBe("u");
+    expect(params.get("t")).toMatch(/^[0-9a-f]{32}$/);
+    expect(params.get("s")).toMatch(/^[0-9a-f]+$/);
+    // Downloads are original-file — never send format/maxBitRate.
+    expect(params.has("format")).toBe(false);
+    expect(params.has("maxBitRate")).toBe(false);
+  });
+
+  it("returns null when not logged in", () => {
+    setSubsonicCreds(null);
+    expect(downloadUrl("t123")).toBeNull();
   });
 });

--- a/frontend/src/lib/subsonic.ts
+++ b/frontend/src/lib/subsonic.ts
@@ -559,6 +559,18 @@ export function streamUrl(
   return `/rest/stream?${params}`;
 }
 
+/**
+ * URL for /rest/download (#35) — original file bytes, no transcoding, served
+ * with Content-Disposition: attachment. Accepts a track id (`t…`) for a single
+ * file or an album id (`al…`) for a ZIP of the whole album.
+ */
+export function downloadUrl(id: string): string | null {
+  const params = authParams();
+  if (!params) return null;
+  params.set("id", id);
+  return `/rest/download?${params}`;
+}
+
 export function artUrl(coverArtId: string, size?: number): string | null {
   // Everything routes through getCoverArt — including absolute fanart.tv /
   // Last.fm URLs. The hub fetches and caches external art behind an SSRF

--- a/frontend/src/pages/ReleaseGroupPage.test.tsx
+++ b/frontend/src/pages/ReleaseGroupPage.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/lib/subsonic", async () => {
     ...actual,
     getAlbum: vi.fn(),
     artUrl: (id: string) => `/art/${id}`,
+    downloadUrl: (id: string) => `/rest/download?id=${id}`,
   };
 });
 
@@ -105,5 +106,33 @@ describe("ReleaseGroupPage track artist (#138)", () => {
     expect(
       screen.getAllByRole("link", { name: "Album Artist" }),
     ).toHaveLength(1);
+  });
+});
+
+describe("ReleaseGroupPage downloads (#35)", () => {
+  it("renders an album Download button linking to /rest/download with the album id", async () => {
+    vi.mocked(getAlbum).mockResolvedValue(makeAlbum());
+    renderAt("al-1");
+
+    await waitFor(() =>
+      expect(screen.getByText("Featured Track")).toBeInTheDocument(),
+    );
+
+    const albumLink = screen.getByTitle("Download album as ZIP");
+    expect(albumLink).toHaveAttribute("href", "/rest/download?id=al-1");
+  });
+
+  it("renders a per-track download link for each song row", async () => {
+    vi.mocked(getAlbum).mockResolvedValue(makeAlbum());
+    renderAt("al-1");
+
+    await waitFor(() =>
+      expect(screen.getByText("Featured Track")).toBeInTheDocument(),
+    );
+
+    const trackLinks = screen.getAllByTitle("Download");
+    expect(trackLinks).toHaveLength(2);
+    expect(trackLinks[0]).toHaveAttribute("href", "/rest/download?id=tr-1");
+    expect(trackLinks[1]).toHaveAttribute("href", "/rest/download?id=tr-2");
   });
 });

--- a/frontend/src/pages/ReleaseGroupPage.tsx
+++ b/frontend/src/pages/ReleaseGroupPage.tsx
@@ -1,10 +1,10 @@
 import { useParams, Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { getAlbum, artUrl } from "@/lib/subsonic";
+import { getAlbum, artUrl, downloadUrl } from "@/lib/subsonic";
 import type { SubsonicSong } from "@/lib/subsonic";
 import { usePlayer } from "@/stores/player";
 import { formatDuration } from "@/lib/format";
-import { Play, Pause, Plus, ChevronRight, Disc, ChevronDown, ChevronUp, FileAudio, Info } from "lucide-react";
+import { Play, Pause, Plus, ChevronRight, Disc, ChevronDown, ChevronUp, Download, FileAudio, Info } from "lucide-react";
 import { useState } from "react";
 import { ShareIdButton } from "@/components/ShareIdButton";
 import { StarButton } from "@/components/StarButton";
@@ -48,6 +48,8 @@ export function ReleaseGroupPage() {
   const toggleTrackMetadata = (trackId: string) => {
     setExpandedTrackId(expandedTrackId === trackId ? null : trackId);
   };
+
+  const albumDownloadHref = downloadUrl(album.id);
 
   return (
     <div className="space-y-8">
@@ -110,6 +112,17 @@ export function ReleaseGroupPage() {
 
             {album.shareId && <ShareIdButton shareId={album.shareId} />}
 
+            {albumDownloadHref && (
+              <a
+                href={albumDownloadHref}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-surface-hover hover:bg-surface text-text-primary rounded-full text-sm font-medium transition-colors cursor-pointer"
+                title="Download album as ZIP"
+              >
+                <Download className="w-4 h-4" />
+                Download
+              </a>
+            )}
+
             <button
               onClick={() => setShowAlbumMetadata(!showAlbumMetadata)}
               className="inline-flex items-center gap-2 px-4 py-2 bg-surface-hover hover:bg-surface text-text-primary rounded-full text-sm font-medium transition-colors cursor-pointer"
@@ -155,7 +168,7 @@ export function ReleaseGroupPage() {
               <th className="py-2.5 px-4 text-left w-24">Bitrate</th>
               <th className="py-2.5 px-4 text-left w-40">Source</th>
               <th className="py-2.5 px-4 text-right w-24">Duration</th>
-              <th className="py-2.5 px-4 text-right w-20"></th>
+              <th className="py-2.5 px-4 text-right w-28"></th>
             </tr>
           </thead>
           <tbody>
@@ -214,6 +227,7 @@ function SongRow({
   // Compilations and "feat." tracks: show the track artist under the title
   // when it differs from the album's release-group artist. (#138)
   const showTrackArtist = !!song.artistId && song.artistId !== albumArtistId;
+  const trackDownloadHref = downloadUrl(song.id);
   return (
     <>
       <tr className="group border-b border-border/50 last:border-0 hover:bg-surface-hover transition-colors">
@@ -283,6 +297,15 @@ function SongRow({
             >
               <Plus className="w-4 h-4" />
             </button>
+            {trackDownloadHref && (
+              <a
+                href={trackDownloadHref}
+                className="opacity-0 group-hover:opacity-100 p-1 text-text-muted hover:text-text-primary transition-all cursor-pointer"
+                title="Download"
+              >
+                <Download className="w-4 h-4" />
+              </a>
+            )}
             <button
               onClick={onToggleMetadata}
               className="opacity-0 group-hover:opacity-100 p-1 text-text-muted hover:text-text-primary transition-all cursor-pointer"

--- a/hub/package.json
+++ b/hub/package.json
@@ -25,12 +25,14 @@
     "jose": "^6.0.11",
     "pino": "^9.6.0",
     "undici": "^7.5.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "yazl": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.13.0",
+    "@types/yazl": "^3.3.1",
     "eslint": "^9.21.0",
     "node-upnp": "^1.3.0",
     "tsx": "^4.19.0",

--- a/hub/src/routes/subsonic/download.ts
+++ b/hub/src/routes/subsonic/download.ts
@@ -1,0 +1,270 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { Readable } from "node:stream";
+import { ZipFile } from "yazl";
+import type { Peer } from "../../federation/peers.js";
+import { sendBinaryError, decodeId } from "../subsonic-response.js";
+import { SubsonicClient } from "../../adapters/subsonic.js";
+import type { SubsonicRouteContext, TrackRow } from "./types.js";
+
+// ── /rest/download (#35) ──────────────────────────────────────────────────────
+// Navidrome/Subsonic semantics: unlike /rest/stream, download returns the
+// ORIGINAL media bytes — no transcoding, no maxBitRate — with a
+// Content-Disposition: attachment header so browsers save instead of play.
+//   id=t<uuid>  → single track, original file
+//   id=al<uuid> → whole album as a ZIP (entries stored, not deflated — audio
+//                 doesn't compress, and store keeps the response streaming)
+// Peer-sourced tracks are proxied raw through /federation/stream, same
+// source-selection as streaming (track_sources.preferred = 1).
+
+interface PreferredSource {
+  instance_id: string;
+  format: string | null;
+  bitrate: number | null;
+  remote_id: string;
+}
+
+/** Common audio content-types → file extension, for sources with no format. */
+const EXT_BY_MIME: Record<string, string> = {
+  "audio/mpeg": "mp3",
+  "audio/flac": "flac",
+  "audio/x-flac": "flac",
+  "audio/mp4": "m4a",
+  "audio/aac": "aac",
+  "audio/ogg": "ogg",
+  "audio/opus": "opus",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+};
+
+/** Strip path separators, Windows-forbidden characters, and control chars. */
+export function sanitizeFilename(name: string): string {
+  const cleaned = name
+    .replace(/[\\/:*?"<>|\u0000-\u001f]/g, "_")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned || "untitled";
+}
+
+/** RFC 6266 Content-Disposition with an ASCII fallback + UTF-8 filename*. */
+export function attachmentDisposition(filename: string): string {
+  const ascii = filename.replace(/[^ -~]/g, "_").replace(/"/g, "'");
+  const utf8 = encodeURIComponent(filename).replace(
+    /['()*]/g,
+    (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
+  );
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${utf8}`;
+}
+
+function extensionFor(format: string | null, contentType: string | null): string | null {
+  if (format) return format;
+  if (!contentType) return null;
+  const mime = contentType.split(";")[0].trim().toLowerCase();
+  return EXT_BY_MIME[mime] ?? null;
+}
+
+export function registerDownload(ctx: SubsonicRouteContext): void {
+  const { app, queries, binaryRoute } = ctx;
+
+  /** Fetch a track's original bytes from its preferred source — no transcode params. */
+  async function fetchRawSource(
+    source: PreferredSource,
+    request: FastifyRequest,
+  ): Promise<Response> {
+    if (source.instance_id === "local") {
+      const client = new SubsonicClient({
+        url: app.config.navidromeUrl,
+        username: app.config.navidromeUsername,
+        password: app.config.navidromePassword,
+      });
+      return client.stream(source.remote_id);
+    }
+    const peer = app.peerRegistry.peers.get(source.instance_id);
+    if (!peer) throw new Error(`Peer ${source.instance_id} not available`);
+    const proxyPeer: Peer = peer;
+    return app.federatedFetch(
+      proxyPeer,
+      `/federation/stream/${encodeURIComponent(source.remote_id)}`,
+      { asUser: request.subsonicUser.username },
+    );
+  }
+
+  async function handleTrackDownload(
+    trackId: string,
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<void> {
+    const track = queries.trackForSong.get(trackId) as TrackRow | undefined;
+    const best = queries.preferredSourceForStream.get(trackId) as
+      | PreferredSource
+      | undefined;
+    if (!track || !best) {
+      sendBinaryError(reply, 404, "Track not found");
+      return;
+    }
+
+    let response: Response;
+    try {
+      response = await fetchRawSource(best, request);
+    } catch {
+      sendBinaryError(reply, 502, "Download source unavailable");
+      return;
+    }
+    if (!response.ok || !response.body) {
+      sendBinaryError(reply, 502, "Download source unavailable");
+      return;
+    }
+
+    const contentType =
+      response.headers.get("content-type") || "application/octet-stream";
+    const ext = extensionFor(best.format, contentType);
+    const base = sanitizeFilename(`${track.artist_name} - ${track.title}`);
+    const filename = ext ? `${base}.${ext}` : base;
+
+    const headers: Record<string, string> = {
+      "content-type": contentType,
+      "content-disposition": attachmentDisposition(filename),
+    };
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) headers["content-length"] = contentLength;
+
+    reply.raw.writeHead(200, headers);
+    Readable.fromWeb(
+      response.body as import("node:stream/web").ReadableStream,
+    ).pipe(reply.raw);
+  }
+
+  async function handleAlbumDownload(
+    rgId: string,
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<void> {
+    const rg = queries.releaseGroupById.get(rgId) as
+      | { id: string; name: string; artist_name: string }
+      | undefined;
+    if (!rg) {
+      sendBinaryError(reply, 404, "Album not found");
+      return;
+    }
+
+    const release = queries.bestReleaseForGroup.get(rgId) as
+      | { id: string }
+      | undefined;
+    const tracks: TrackRow[] = release
+      ? (queries.tracksForRelease.all(release.id) as TrackRow[])
+      : [];
+    if (tracks.length === 0) {
+      sendBinaryError(reply, 404, "Album has no tracks");
+      return;
+    }
+
+    const zipName = `${sanitizeFilename(`${rg.artist_name} - ${rg.name}`)}.zip`;
+    reply.raw.writeHead(200, {
+      "content-type": "application/zip",
+      "content-disposition": attachmentDisposition(zipName),
+    });
+
+    const zip = new ZipFile();
+    zip.outputStream.pipe(reply.raw);
+
+    const multiDisc = tracks.some((t) => (t.disc_number ?? 1) > 1);
+    const usedNames = new Set<string>();
+
+    // Sequential on purpose: one upstream fetch open at a time, so a large
+    // album never holds N connections to Navidrome/peers. yazl writes entries
+    // in order, so each stream is fully consumed before the next fetch starts.
+    for (const track of tracks) {
+      if (reply.raw.destroyed) return; // client went away mid-zip
+
+      const best = queries.preferredSourceForStream.get(track.id) as
+        | PreferredSource
+        | undefined;
+      if (!best) {
+        request.log.warn(`Album download: no source for track ${track.id}, skipping`);
+        continue;
+      }
+
+      let response: Response;
+      try {
+        response = await fetchRawSource(best, request);
+      } catch {
+        request.log.warn(`Album download: fetch failed for track ${track.id}, skipping`);
+        continue;
+      }
+      if (!response.ok || !response.body) {
+        request.log.warn(`Album download: upstream ${response.status} for track ${track.id}, skipping`);
+        continue;
+      }
+
+      const ext = extensionFor(best.format, response.headers.get("content-type"));
+      const nn = String(track.track_number ?? 0).padStart(2, "0");
+      const prefix = multiDisc ? `${track.disc_number ?? 1}-${nn}` : nn;
+      let entryName = sanitizeFilename(`${prefix} - ${track.title}`);
+      if (ext) entryName += `.${ext}`;
+      // yazl throws on duplicate entry names — disambiguate defensively.
+      while (usedNames.has(entryName)) entryName = `_${entryName}`;
+      usedNames.add(entryName);
+
+      const nodeStream = Readable.fromWeb(
+        response.body as import("node:stream/web").ReadableStream,
+      );
+      zip.addReadStream(nodeStream, entryName, { compress: false });
+
+      // Wait for yazl to drain this entry before opening the next fetch.
+      // If the client disconnects, the pipe stalls forever — bail on close.
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const onClose = () => {
+            nodeStream.destroy();
+            resolve();
+          };
+          reply.raw.once("close", onClose);
+          nodeStream.once("end", () => {
+            reply.raw.off("close", onClose);
+            resolve();
+          });
+          nodeStream.once("error", (err) => {
+            reply.raw.off("close", onClose);
+            reject(err);
+          });
+        });
+      } catch (err) {
+        // Upstream died mid-entry: the ZIP is unsalvageable (bytes already
+        // written) — kill the connection so the client sees a failure.
+        request.log.warn(
+          `Album download: stream error for track ${track.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        reply.raw.destroy();
+        return;
+      }
+      if (reply.raw.destroyed) return;
+    }
+
+    zip.end();
+  }
+
+  binaryRoute("/download", async (request, reply) => {
+    const q = request.query as Record<string, string>;
+    const id = q.id ?? "";
+
+    if (id.startsWith("al")) {
+      let rgId: string;
+      try {
+        rgId = decodeId(id, "al");
+      } catch {
+        sendBinaryError(reply, 400, "Invalid album ID");
+        return;
+      }
+      await handleAlbumDownload(rgId, request, reply);
+      return;
+    }
+
+    let trackId: string;
+    try {
+      trackId = decodeId(id, "t");
+    } catch {
+      sendBinaryError(reply, 400, "Invalid download ID");
+      return;
+    }
+    await handleTrackDownload(trackId, request, reply);
+  });
+}

--- a/hub/src/routes/subsonic/index.ts
+++ b/hub/src/routes/subsonic/index.ts
@@ -9,6 +9,7 @@ import { registerSearch } from "./search.js";
 import { registerPlaylists } from "./playlists.js";
 import { registerAnnotations } from "./annotations.js";
 import { registerStream } from "./stream.js";
+import { registerDownload } from "./download.js";
 
 // Extend Fastify app type for stream tracking
 declare module "fastify" {
@@ -22,7 +23,7 @@ declare module "fastify" {
 // ping, getLicense, getOpenSubsonicExtensions (public), getUser,
 // getMusicFolders, getGenres, getArtists, getIndexes, getArtist,
 // getArtistInfo2, getAlbumList2, getAlbum, getSong, search3, getCoverArt
-// (binary), stream (binary), download (binary alias), star, unstar,
+// (binary), stream (binary), download (binary, own handler since #35), star, unstar,
 // getStarred2, getStarred, getPlaylists, getPlaylist, createPlaylist,
 // updatePlaylist, deletePlaylist, scrobble, getNowPlaying.
 
@@ -94,6 +95,7 @@ export const subsonicRoutes: FastifyPluginAsync = async (app) => {
   registerBrowsing(ctx);
   registerSearch(ctx);
   registerStream(ctx);
+  registerDownload(ctx);
   registerAnnotations(ctx);
   registerPlaylists(ctx);
 };

--- a/hub/src/routes/subsonic/stream.ts
+++ b/hub/src/routes/subsonic/stream.ts
@@ -354,5 +354,6 @@ try {
 }
 
   binaryRoute("/stream", handleStream);
-  binaryRoute("/download", handleStream); // alias — clients use interchangeably
+  // /download is no longer a stream alias — it returns original bytes with a
+  // Content-Disposition header (and album ZIPs). See download.ts (#35).
 }

--- a/hub/test/download.test.ts
+++ b/hub/test/download.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for /rest/download (#35) — Navidrome-style download semantics.
+ *
+ * Covers:
+ *   - sanitizeFilename / attachmentDisposition unit behavior
+ *   - Bad / missing ID → 400; unknown track/album → 404
+ *   - Track download: original bytes, attachment disposition, transcode
+ *     params ignored (raw fetch upstream)
+ *   - Album download: streaming ZIP with one stored entry per track
+ *
+ * Peer-path coverage (download routed raw through /federation/stream) rides
+ * the two-hub harness in stream.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../src/server.js";
+import { setPassword } from "../src/auth/passwords.js";
+import { mergeLibraries } from "../src/library/merge.js";
+import {
+  sanitizeFilename,
+  attachmentDisposition,
+} from "../src/routes/subsonic/download.js";
+
+const FAKE_AUDIO = Buffer.from([0xff, 0xfb, 0x90, 0x00, 0xaa, 0xbb, 0xcc, 0xdd]);
+
+// ── Unit: filename helpers ────────────────────────────────────────────────────
+
+describe("sanitizeFilename", () => {
+  it("strips path separators and Windows-forbidden characters", () => {
+    expect(sanitizeFilename('AC/DC: "Back*|<in>" Black?')).toBe(
+      "AC_DC_ _Back___in__ Black_",
+    );
+  });
+
+  it("collapses whitespace and falls back on empty input", () => {
+    expect(sanitizeFilename("  a   b  ")).toBe("a b");
+    expect(sanitizeFilename("///")).toBe("___");
+    expect(sanitizeFilename("   ")).toBe("untitled");
+  });
+});
+
+describe("attachmentDisposition", () => {
+  it("emits ASCII fallback plus RFC 5987 UTF-8 filename*", () => {
+    const d = attachmentDisposition("Sigur Rós - Ágætis.flac");
+    expect(d).toMatch(/^attachment; filename="Sigur R_s - _g_tis\.flac"/);
+    expect(d).toContain("filename*=UTF-8''Sigur%20R%C3%B3s%20-%20%C3%81g%C3%A6tis.flac");
+  });
+
+  it("never emits a double quote in the ASCII fallback", () => {
+    const d = attachmentDisposition('a"b.mp3');
+    expect(d).toContain(`filename="a'b.mp3"`);
+  });
+});
+
+// ── Integration harness ───────────────────────────────────────────────────────
+
+/**
+ * Fake Navidrome that serves audio bytes for every request and records each
+ * request URL so tests can assert which params Poutine forwarded upstream.
+ */
+function startCapturingNavidrome(): Promise<{
+  server: http.Server;
+  port: number;
+  requests: string[];
+}> {
+  const requests: string[] = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      requests.push(req.url ?? "/");
+      res.writeHead(200, {
+        "content-type": "audio/mpeg",
+        "content-length": String(FAKE_AUDIO.length),
+      });
+      res.end(FAKE_AUDIO);
+    });
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ server, port: (server.address() as AddressInfo).port, requests });
+    });
+  });
+}
+
+function seedUser(app: FastifyInstance) {
+  const enc = setPassword("secret", app.passwordKey);
+  app.db
+    .prepare(
+      "INSERT INTO users (id, username, password_enc, is_admin) VALUES (?, ?, ?, 1)",
+    )
+    .run("user-1", "tester", enc);
+}
+
+/** Seed a local two-track album and merge. */
+function seedLocalAlbum(app: FastifyInstance) {
+  app.db
+    .prepare(
+      `INSERT INTO instance_artists (id, instance_id, remote_id, name, album_count)
+       VALUES ('local:art-1', 'local', 'art-1', 'Test Artist', 1)`,
+    )
+    .run();
+  app.db
+    .prepare(
+      `INSERT INTO instance_albums
+       (id, instance_id, remote_id, name, artist_id, artist_name, track_count, cover_art_id)
+       VALUES ('local:alb-1', 'local', 'alb-1', 'Test Album', 'local:art-1', 'Test Artist', 2, NULL)`,
+    )
+    .run();
+  const insertTrack = app.db.prepare(
+    `INSERT INTO instance_tracks
+     (id, instance_id, remote_id, album_id, title, artist_name, track_number, duration_ms, format, bitrate)
+     VALUES (?, 'local', ?, 'local:alb-1', ?, 'Test Artist', ?, 180000, 'mp3', 320)`,
+  );
+  insertTrack.run("local:trk-1", "trk-1", "First Track", 1);
+  insertTrack.run("local:trk-2", "trk-2", "Second Track", 2);
+  mergeLibraries(app.db);
+}
+
+describe("download — /rest/download", () => {
+  let app: FastifyInstance;
+  let navidrome: http.Server;
+  let navRequests: string[];
+
+  beforeEach(async () => {
+    const nav = await startCapturingNavidrome();
+    navidrome = nav.server;
+    navRequests = nav.requests;
+
+    app = await buildApp({
+      databasePath: ":memory:",
+      jwtSecret: "test-secret",
+      navidromeUrl: `http://127.0.0.1:${nav.port}`,
+      navidromeUsername: "admin",
+      navidromePassword: "admin",
+    });
+    await app.ready();
+    seedUser(app);
+    seedLocalAlbum(app);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await new Promise<void>((resolve) => navidrome.close(() => resolve()));
+  });
+
+  function trackId(title: string): string {
+    const row = app.db
+      .prepare("SELECT id FROM unified_tracks WHERE title = ?")
+      .get(title) as { id: string };
+    expect(row).toBeDefined();
+    return row.id;
+  }
+
+  function albumId(): string {
+    const row = app.db
+      .prepare("SELECT id FROM unified_release_groups LIMIT 1")
+      .get() as { id: string };
+    expect(row).toBeDefined();
+    return row.id;
+  }
+
+  it("missing id → 400", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/download?u=tester&p=secret&f=json",
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("unknown-prefix id → 400", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/download?u=tester&p=secret&f=json&id=xyz999",
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("unknown track → 404", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/download?u=tester&p=secret&f=json&id=t00000000-0000-0000-0000-000000000000",
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("unknown album → 404", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/rest/download?u=tester&p=secret&f=json&id=al00000000-0000-0000-0000-000000000000",
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("track download → original bytes, attachment disposition, named from metadata", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/rest/download?u=tester&p=secret&f=json&id=t${trackId("First Track")}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/audio\/mpeg/);
+    expect(res.headers["content-length"]).toBe(String(FAKE_AUDIO.length));
+    expect(res.headers["content-disposition"]).toBe(
+      attachmentDisposition("Test Artist - First Track.mp3"),
+    );
+    expect(Buffer.from(res.rawPayload)).toEqual(FAKE_AUDIO);
+  });
+
+  it("track download ignores transcode params — upstream fetch is raw", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/rest/download?u=tester&p=secret&f=json&id=t${trackId("First Track")}&format=opus&maxBitRate=64`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const streamReq = navRequests.find((u) => u.includes("/rest/stream"));
+    expect(streamReq).toBeDefined();
+    expect(streamReq).not.toContain("format=");
+    expect(streamReq).not.toContain("maxBitRate=");
+  });
+
+  it("album download → streaming ZIP with one stored entry per track", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/rest/download?u=tester&p=secret&f=json&id=al${albumId()}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/zip");
+    expect(res.headers["content-disposition"]).toBe(
+      attachmentDisposition("Test Artist - Test Album.zip"),
+    );
+
+    const zip = Buffer.from(res.rawPayload);
+    // Local file header + end-of-central-directory signatures.
+    expect(zip.subarray(0, 4)).toEqual(Buffer.from("PK\x03\x04", "binary"));
+    expect(zip.includes(Buffer.from("PK\x05\x06", "binary"))).toBe(true);
+    // Entry names are stored verbatim in the archive.
+    expect(zip.includes(Buffer.from("01 - First Track.mp3"))).toBe(true);
+    expect(zip.includes(Buffer.from("02 - Second Track.mp3"))).toBe(true);
+    // Audio bytes appear once per entry (stored, not deflated).
+    expect(zip.includes(FAKE_AUDIO)).toBe(true);
+    // Both tracks were fetched raw from Navidrome.
+    const streamReqs = navRequests.filter((u) => u.includes("/rest/stream"));
+    expect(streamReqs).toHaveLength(2);
+    for (const u of streamReqs) {
+      expect(u).not.toContain("format=");
+      expect(u).not.toContain("maxBitRate=");
+    }
+  });
+});

--- a/hub/test/stream.test.ts
+++ b/hub/test/stream.test.ts
@@ -1,5 +1,6 @@
 /**
- * Integration tests for /rest/stream (and /rest/download alias).
+ * Integration tests for /rest/stream (plus one /rest/download local-path
+ * smoke test — full download coverage lives in download.test.ts, #35).
  *
  * Covers:
  *   - Bad / missing ID → Subsonic error 70
@@ -355,7 +356,7 @@ describe("stream — local source", () => {
     expect(Buffer.from(res.rawPayload)).toEqual(FAKE_AUDIO);
   });
 
-  it("/rest/download alias behaves identically to /rest/stream", async () => {
+  it("/rest/download serves the same bytes as stream, as an attachment (#35)", async () => {
     const track = app.db
       .prepare("SELECT id FROM unified_tracks LIMIT 1")
       .get() as { id: string };
@@ -367,6 +368,7 @@ describe("stream — local source", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.headers["content-type"]).toMatch(/audio\/mpeg/);
+    expect(res.headers["content-disposition"]).toMatch(/^attachment/);
     expect(Buffer.from(res.rawPayload)).toEqual(FAKE_AUDIO);
   });
 });
@@ -496,6 +498,21 @@ describe("stream — peer source", () => {
     expect(res.statusCode).toBe(206);
     expect(res.headers["content-range"]).toBe(`bytes 1-4/${FAKE_AUDIO.length}`);
     expect(Buffer.from(res.rawPayload)).toEqual(FAKE_AUDIO.subarray(1, 5));
+  });
+
+  it("downloads peer-sourced tracks raw through federation with attachment disposition (#35)", async () => {
+    const track = appA.db
+      .prepare("SELECT id FROM unified_tracks LIMIT 1")
+      .get() as { id: string };
+
+    const res = await appA.inject({
+      method: "GET",
+      url: `/rest/download?u=tester&p=secret&f=json&id=t${track.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-disposition"]).toMatch(/^attachment/);
+    expect(Buffer.from(res.rawPayload)).toEqual(FAKE_AUDIO);
   });
 
   it("records a kind='proxy' stream on the source hub when a peer fetches via /federation/stream (#121)", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+      yazl:
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.21.0
@@ -141,6 +144,9 @@ importers:
       '@types/node':
         specifier: ^22.13.0
         version: 22.19.15
+      '@types/yazl':
+        specifier: ^3.3.1
+        version: 3.3.1
       eslint:
         specifier: ^9.21.0
         version: 9.39.4(jiti@2.6.1)
@@ -1003,6 +1009,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/yazl@3.3.1':
+    resolution: {integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==}
+
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1208,6 +1217,10 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2510,6 +2523,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3226,6 +3242,10 @@ snapshots:
     dependencies:
       '@types/node': 24.12.0
 
+  '@types/yazl@3.3.1':
+    dependencies:
+      '@types/node': 24.12.0
+
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3472,6 +3492,8 @@ snapshots:
       electron-to-chromium: 1.5.321
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -4810,6 +4832,10 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Implements #35 — download buttons for tracks and whole albums, matching Navidrome's download semantics. Closes #35.

### Backend
- `/rest/download` is no longer an alias for `stream` (`hub/src/routes/subsonic/download.ts`). Per the Subsonic spec it now returns the **original media bytes** — `format`/`maxBitRate` are ignored — with `Content-Disposition: attachment`.
- **Track id (`t…`)** → single file, named `Artist - Title.ext` (RFC 6266 ASCII fallback + UTF-8 `filename*`; extension from the preferred source's format, content-type fallback).
- **Album id (`al…`)** → streaming ZIP named `Artist - Album.zip` with `NN - Title.ext` entries (`D-NN` when multi-disc). Entries are stored, not deflated (audio doesn't compress; keeps the response streaming). Upstream fetches are sequential — one open connection to Navidrome/a peer at a time. Tracks whose source fails are skipped with a warning so the ZIP stays valid.
- Peer-sourced tracks proxy raw through `/federation/stream` with the same merge-time preferred-source selection as streaming. No federation contract change.
- Cast tokens are not accepted (auth path-gates them to `/rest/stream` only, #218).
- New dependency: `yazl` (+ types).

### Frontend
- `downloadUrl()` helper in `lib/subsonic.ts` (authed URL, no transcode params).
- Album header: **Download** pill (ZIP of the album).
- Track rows: hover download icon next to Add-to-queue.

### Tests
- `hub/test/download.test.ts`: filename-helper units, 400/404 cases, track download (attachment header, raw upstream fetch asserted via capturing fake Navidrome), album ZIP (signatures, entry names, stored bytes).
- Peer-path download test added to the two-hub harness in `stream.test.ts`.
- Frontend: `downloadUrl` unit tests + ReleaseGroupPage button/link tests.
- `pnpm verify` ✅, `pnpm lint` ✅ (zero output), `pnpm test:federation` ✅ (84 compat tests, all hubs).

### Docs
- `docs/opensubsonic.md` download row updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Q3riZ78G26ohMgPDh8F7u