### PR TITLE
feat(spa): full-size album art lightbox on album detail page (#200)

### DIFF
--- a/frontend/src/components/Lightbox.test.tsx
+++ b/frontend/src/components/Lightbox.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Lightbox } from "./Lightbox";
+
+describe("Lightbox (#200)", () => {
+  it("renders the image inside a dialog", () => {
+    render(<Lightbox src="/art/full" alt="Cover" onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Cover" })).toHaveAttribute(
+      "src",
+      "/art/full",
+    );
+  });
+
+  it("closes on backdrop click", () => {
+    const onClose = vi.fn();
+    render(<Lightbox src="/art/full" alt="Cover" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not close when clicking the image itself", () => {
+    const onClose = vi.fn();
+    render(<Lightbox src="/art/full" alt="Cover" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("img", { name: "Cover" }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    render(<Lightbox src="/art/full" alt="Cover" onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Lightbox.tsx
+++ b/frontend/src/components/Lightbox.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+
+/**
+ * Full-viewport image overlay (#200). Dismisses on backdrop click or Escape;
+ * clicking the image itself does not dismiss. Escape listener is
+ * document-level so it fires regardless of what has focus.
+ */
+export function Lightbox({
+  src,
+  alt,
+  onClose,
+}: {
+  src: string;
+  alt: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt}
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-8"
+    >
+      <img
+        src={src}
+        alt={alt}
+        onClick={(e) => e.stopPropagation()}
+        className="max-w-full max-h-full object-contain"
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/ReleaseGroupPage.test.tsx
+++ b/frontend/src/pages/ReleaseGroupPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { ReleaseGroupPage } from "./ReleaseGroupPage";
@@ -106,6 +106,69 @@ describe("ReleaseGroupPage track artist (#138)", () => {
     expect(
       screen.getAllByRole("link", { name: "Album Artist" }),
     ).toHaveLength(1);
+  });
+});
+
+describe("ReleaseGroupPage cover art lightbox (#200)", () => {
+  it("opens a lightbox with the full-size cover when the art is clicked", async () => {
+    const album = makeAlbum();
+    album.coverArt = "cover-1";
+    vi.mocked(getAlbum).mockResolvedValue(album);
+    renderAt("al-1");
+
+    await waitFor(() =>
+      expect(screen.getByText("Featured Track")).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: /view full-size cover art/i }),
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("img", { name: "Comp Album" }),
+    ).toHaveAttribute("src", "/art/cover-1");
+  });
+
+  it("closes the lightbox on backdrop click but not on image click", async () => {
+    const album = makeAlbum();
+    album.coverArt = "cover-1";
+    vi.mocked(getAlbum).mockResolvedValue(album);
+    renderAt("al-1");
+
+    await waitFor(() =>
+      expect(screen.getByText("Featured Track")).toBeInTheDocument(),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /view full-size cover art/i }),
+    );
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("img", { name: "Comp Album" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the lightbox on Escape", async () => {
+    const album = makeAlbum();
+    album.coverArt = "cover-1";
+    vi.mocked(getAlbum).mockResolvedValue(album);
+    renderAt("al-1");
+
+    await waitFor(() =>
+      expect(screen.getByText("Featured Track")).toBeInTheDocument(),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /view full-size cover art/i }),
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/ReleaseGroupPage.tsx
+++ b/frontend/src/pages/ReleaseGroupPage.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { ShareIdButton } from "@/components/ShareIdButton";
 import { StarButton } from "@/components/StarButton";
 import { ErrorMessage } from "@/components/ui/ErrorMessage";
+import { Lightbox } from "@/components/Lightbox";
 
 function hashColor(name: string): string {
   let hash = 0;
@@ -25,6 +26,7 @@ export function ReleaseGroupPage() {
   const currentTrackId = currentIndex >= 0 ? queue[currentIndex]?.id : undefined;
   const [expandedTrackId, setExpandedTrackId] = useState<string | null>(null);
   const [showAlbumMetadata, setShowAlbumMetadata] = useState(false);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
 
   const { data: album, isLoading, error } = useQuery({
     queryKey: ["album", id],
@@ -69,11 +71,18 @@ export function ReleaseGroupPage() {
           style={{ backgroundColor: hashColor(album.name) }}
         >
           {album.coverArt ? (
-            <img
-              src={artUrl(album.coverArt, 400) ?? undefined}
-              alt={album.name}
-              className="w-full h-full object-cover"
-            />
+            <button
+              type="button"
+              onClick={() => setLightboxOpen(true)}
+              className="w-full h-full cursor-pointer"
+              aria-label={`View full-size cover art for ${album.name}`}
+            >
+              <img
+                src={artUrl(album.coverArt, 400) ?? undefined}
+                alt={album.name}
+                className="w-full h-full object-cover"
+              />
+            </button>
           ) : (
             <Disc className="w-16 h-16 text-white/30" />
           )}
@@ -189,6 +198,14 @@ export function ReleaseGroupPage() {
           </tbody>
         </table>
       </div>
+
+      {lightboxOpen && album.coverArt && (
+        <Lightbox
+          src={artUrl(album.coverArt) ?? ""}
+          alt={album.name}
+          onClose={() => setLightboxOpen(false)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #200.

Clicking the cover art on the album detail page (`ReleaseGroupPage`) now opens a full-size lightbox — a fixed full-viewport overlay with a dimmed backdrop and the image centered, constrained to the viewport.

## Behavior
- Cover art is wrapped in a keyboard-accessible `<button>` (aria-label) — only rendered when the album has cover art.
- Lightbox requests full-size art (`artUrl` without a `size` param).
- Dismiss: click anywhere **not** on the image, or press Escape (document-level listener, cleaned up on unmount). Clicking the image itself does not dismiss.
- Overlay is `role="dialog" aria-modal="true"`.

## Implementation
- New reusable `frontend/src/components/Lightbox.tsx` + `Lightbox.test.tsx` (4 tests).
- `ReleaseGroupPage.tsx`: `lightboxOpen` state + button wrapper; 3 new page-level tests.

## Verification
- `pnpm verify` green: hub + frontend suites (133 frontend tests incl. 7 new), typecheck, boundary lint.
- `pnpm lint` zero errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwwPcrohddTUN7kmQVedQC