### PR TITLE
fix(spa): unmute restores previous volume instead of near-max (#207)

### DIFF
--- a/frontend/src/components/player/PlayerBar.test.tsx
+++ b/frontend/src/components/player/PlayerBar.test.tsx
@@ -37,6 +37,8 @@ beforeEach(() => {
     volume: 0.8,
     castVolume: 50,
     castVolumeCap: 50,
+    prevVolume: null,
+    prevCastVolume: null,
   });
 });
 
@@ -106,6 +108,51 @@ describe("PlayerBar render stability", () => {
 
     const sameImg = container.querySelector("img");
     expect(sameImg!.getAttribute("src")).toBe(firstSrc);
+  });
+});
+
+describe("PlayerBar local speaker button (#207)", () => {
+  function renderBar() {
+    return render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}><MemoryRouter>
+        <PlayerBar />
+      </MemoryRouter></QueryClientProvider>,
+    );
+  }
+
+  it("mute then unmute restores the previous volume", () => {
+    usePlayer.setState({
+      queue: [track("trk-1")],
+      currentIndex: 0,
+      volume: 0.36,
+    });
+    const { getByRole } = renderBar();
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Mute" }));
+    });
+    expect(usePlayer.getState().volume).toBe(0);
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Unmute" }));
+    });
+    expect(usePlayer.getState().volume).toBe(0.36);
+  });
+
+  it("unmuting with no remembered level lands at the halfway slider position", () => {
+    // Raw 0.25 — the slider is square-law (position = sqrt(volume)), so 0.25
+    // renders at 50%. Asserting a raw ~0.5 here would be the original bug.
+    usePlayer.setState({
+      queue: [track("trk-1")],
+      currentIndex: 0,
+      volume: 0,
+    });
+    const { getByRole } = renderBar();
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Unmute" }));
+    });
+    expect(usePlayer.getState().volume).toBe(0.25);
   });
 });
 
@@ -203,6 +250,35 @@ describe("PlayerBar cast volume slider", () => {
       vi.advanceTimersByTime(200);
     });
     expect(api.sonosSetVolume).toHaveBeenCalledWith("RINCON_1", 35);
+  });
+
+  it("cast speaker button mutes and unmutes on the device, restoring the previous level (#207)", () => {
+    usePlayer.setState({
+      sink: { type: "sonos", deviceId: "RINCON_1", deviceName: "Kitchen" },
+      castVolume: 30,
+      castVolumeCap: 50,
+      queue: [track("trk-1")],
+      currentIndex: 0,
+    });
+
+    const { getByRole } = render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}><MemoryRouter>
+        <PlayerBar />
+      </MemoryRouter></QueryClientProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Mute" }));
+    });
+    expect(usePlayer.getState().castVolume).toBe(0);
+    // Pushed to the device immediately (no debounce on the button).
+    expect(api.sonosSetVolume).toHaveBeenCalledWith("RINCON_1", 0);
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Unmute" }));
+    });
+    expect(usePlayer.getState().castVolume).toBe(30);
+    expect(api.sonosSetVolume).toHaveBeenCalledWith("RINCON_1", 30);
   });
 
   it("stops the previous Sonos device when sink switches to local (#198)", async () => {

--- a/frontend/src/components/player/PlayerBar.tsx
+++ b/frontend/src/components/player/PlayerBar.tsx
@@ -59,6 +59,8 @@ export function PlayerBar() {
     toggleShuffle,
     cycleRepeat,
     sink,
+    toggleMute,
+    toggleCastMute,
   } = usePlayer();
 
   const currentTrack =
@@ -863,9 +865,8 @@ export function PlayerBar() {
               aria-label={castVolume === 0 ? "Unmute" : "Mute"}
               onClick={() => {
                 if (!deviceId) return;
-                const target = castVolume > 0 ? 0 : Math.min(20, castVolumeCap);
+                const target = toggleCastMute();
                 lastCastVolumeDragRef.current = Date.now();
-                setCastVolume(target);
                 void sonosSetVolume(deviceId, target).catch(() => {});
               }}
               className="p-1 text-text-muted hover:text-text-primary transition-colors"
@@ -903,7 +904,7 @@ export function PlayerBar() {
           <>
             <button
               aria-label={volume === 0 ? "Unmute" : "Mute"}
-              onClick={() => setVolume(volume > 0 ? 0 : 0.8)}
+              onClick={() => toggleMute()}
               className="p-1 text-text-muted hover:text-text-primary transition-colors"
             >
               {volume === 0 ? (

--- a/frontend/src/stores/player.test.ts
+++ b/frontend/src/stores/player.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { usePlayer } from "./player";
+import { usePlayer, DEFAULT_SONOS_VOLUME_CAP } from "./player";
 import type { SubsonicSong } from "@/lib/subsonic";
 
 const song = (id: string): SubsonicSong =>
@@ -145,6 +145,85 @@ describe("player store castVolume", () => {
   it("setCastVolumeCap leaves a value below the new cap untouched", () => {
     usePlayer.setState({ castVolume: 20, castVolumeCap: 50 });
     usePlayer.getState().setCastVolumeCap(40);
+    expect(usePlayer.getState().castVolume).toBe(20);
+  });
+});
+
+describe("player store mute/unmute (#207)", () => {
+  beforeEach(() => {
+    usePlayer.setState({
+      volume: 0.8,
+      prevVolume: null,
+      castVolume: DEFAULT_SONOS_VOLUME_CAP,
+      castVolumeCap: DEFAULT_SONOS_VOLUME_CAP,
+      prevCastVolume: null,
+    });
+  });
+
+  it("toggleMute remembers the current volume and mutes to 0", () => {
+    usePlayer.getState().toggleMute();
+    const s = usePlayer.getState();
+    expect(s.volume).toBe(0);
+    expect(s.prevVolume).toBe(0.8);
+  });
+
+  it("toggleMute then toggleMute again restores the previous volume", () => {
+    usePlayer.getState().toggleMute();
+    usePlayer.getState().toggleMute();
+    const s = usePlayer.getState();
+    expect(s.volume).toBe(0.8);
+    expect(s.prevVolume).toBeNull();
+  });
+
+  it("unmuting with no remembered value falls back to slider-halfway (0.25)", () => {
+    usePlayer.setState({ volume: 0, prevVolume: null });
+    usePlayer.getState().toggleMute();
+    expect(usePlayer.getState().volume).toBe(0.25);
+  });
+
+  it("unmuting never lands on 0 even if the remembered value was 0", () => {
+    usePlayer.setState({ volume: 0, prevVolume: 0 });
+    usePlayer.getState().toggleMute();
+    expect(usePlayer.getState().volume).toBe(0.25);
+  });
+
+  it("toggleCastMute remembers the current cast volume and mutes to 0", () => {
+    usePlayer.setState({ castVolume: 35 });
+    const result = usePlayer.getState().toggleCastMute();
+    expect(result).toBe(0);
+    const s = usePlayer.getState();
+    expect(s.castVolume).toBe(0);
+    expect(s.prevCastVolume).toBe(35);
+  });
+
+  it("toggleCastMute then toggleCastMute again restores the previous cast volume", () => {
+    usePlayer.setState({ castVolume: 35 });
+    usePlayer.getState().toggleCastMute();
+    const result = usePlayer.getState().toggleCastMute();
+    expect(result).toBe(35);
+    expect(usePlayer.getState().castVolume).toBe(35);
+    expect(usePlayer.getState().prevCastVolume).toBeNull();
+  });
+
+  it("unmuting cast with no remembered value falls back to min(20, cap)", () => {
+    usePlayer.setState({ castVolume: 0, prevCastVolume: null, castVolumeCap: 50 });
+    const result = usePlayer.getState().toggleCastMute();
+    expect(result).toBe(20);
+    expect(usePlayer.getState().castVolume).toBe(20);
+  });
+
+  it("unmuting cast falls back to the cap when it is below 20", () => {
+    usePlayer.setState({ castVolume: 0, prevCastVolume: null, castVolumeCap: 10 });
+    const result = usePlayer.getState().toggleCastMute();
+    expect(result).toBe(10);
+  });
+
+  it("restored cast volume clamps to a lowered cap", () => {
+    usePlayer.setState({ castVolume: 35, castVolumeCap: 50 });
+    usePlayer.getState().toggleCastMute();
+    usePlayer.setState({ castVolumeCap: 20 });
+    const result = usePlayer.getState().toggleCastMute();
+    expect(result).toBe(20);
     expect(usePlayer.getState().castVolume).toBe(20);
   });
 });

--- a/frontend/src/stores/player.ts
+++ b/frontend/src/stores/player.ts
@@ -32,6 +32,13 @@ interface PlayerState {
   castVolume: number;
   /** Authoritative cap from the hub; mirrored to bound the cast slider. */
   castVolumeCap: number;
+  /**
+   * Volume remembered across a mute/unmute cycle (#207). Session-scoped
+   * (not persisted) — a fresh load has nothing to restore, which is fine
+   * since `setVolume`/`setCastVolume` already seed sane defaults.
+   */
+  prevVolume: number | null;
+  prevCastVolume: number | null;
   currentTime: number;
   duration: number;
   shuffle: boolean;
@@ -74,6 +81,21 @@ interface PlayerState {
   setVolume: (volume: number) => void;
   setCastVolume: (level: number) => void;
   setCastVolumeCap: (cap: number) => void;
+  /**
+   * Mute/unmute the local `<audio>` volume, remembering the pre-mute level
+   * so unmuting restores it (#207). Falls back to slider-halfway (raw 0.25,
+   * since the slider is square-law — see PlayerBar) when there's nothing to
+   * restore, or when the remembered value was itself 0.
+   */
+  toggleMute: () => void;
+  /**
+   * Mute/unmute cast volume, remembering the pre-mute level (#207). Returns
+   * the new level so the caller can push it to the Sonos device — the store
+   * doesn't own that side effect. Falls back to `min(20, castVolumeCap)`,
+   * matching the pre-existing unmute default, and clamps a restored value
+   * to the current cap in case it changed while muted.
+   */
+  toggleCastMute: () => number;
   setCurrentTime: (time: number) => void;
   setDuration: (duration: number) => void;
   toggleShuffle: () => void;
@@ -88,6 +110,8 @@ export const usePlayer = create<PlayerState>((set, get) => ({
   volume: parseFloat(localStorage.getItem("volume") || "0.8"),
   castVolume: DEFAULT_SONOS_VOLUME_CAP,
   castVolumeCap: DEFAULT_SONOS_VOLUME_CAP,
+  prevVolume: null,
+  prevCastVolume: null,
   currentTime: 0,
   duration: 0,
   shuffle: false,
@@ -216,6 +240,33 @@ export const usePlayer = create<PlayerState>((set, get) => ({
       // slider position above its own max.
       castVolume: Math.min(state.castVolume, castVolumeCap),
     })),
+  toggleMute: () =>
+    set((state) => {
+      if (state.volume > 0) {
+        localStorage.setItem("volume", "0");
+        return { volume: 0, prevVolume: state.volume };
+      }
+      // Unmute: restore the remembered level, or fall back to slider-halfway
+      // (raw 0.25 under the square-law slider) if there's nothing usable to
+      // restore to (#207).
+      const restored =
+        state.prevVolume && state.prevVolume > 0 ? state.prevVolume : 0.25;
+      localStorage.setItem("volume", String(restored));
+      return { volume: restored, prevVolume: null };
+    }),
+  toggleCastMute: () => {
+    const state = get();
+    if (state.castVolume > 0) {
+      set({ castVolume: 0, prevCastVolume: state.castVolume });
+      return 0;
+    }
+    const restored =
+      state.prevCastVolume && state.prevCastVolume > 0
+        ? Math.min(state.prevCastVolume, state.castVolumeCap)
+        : Math.min(20, state.castVolumeCap);
+    set({ castVolume: restored, prevCastVolume: null });
+    return restored;
+  },
   setCurrentTime: (currentTime) => set({ currentTime }),
   setDuration: (duration) => set({ duration }),
   toggleShuffle: () => set((state) => ({ shuffle: !state.shuffle })),


### PR DESCRIPTION
Closes #207.

Clicking the speaker icon to unmute set local volume to raw `0.8`, which the square-law volume slider (`position = sqrt(volume)`) renders at ~90% — the "nearly max" from the issue.

## Behavior
- Muting via the speaker button remembers the current level (session-scoped, not persisted); unmuting restores it.
- No remembered level (fresh session, or slider dragged to 0 manually): local audio unmutes to halfway slider position (raw 0.25 under the square law); Sonos cast keeps the pre-existing `min(20, castVolumeCap)` fallback.
- A restored cast level is clamped to the current cap (the cap may have changed while muted). Unmute never lands on 0.

## Implementation
- `frontend/src/stores/player.ts`: `prevVolume`/`prevCastVolume` state + `toggleMute()` / `toggleCastMute()` actions. `toggleCastMute` returns the new level so `PlayerBar` can push it to the Sonos device — the store doesn't own that side effect.
- `PlayerBar.tsx`: both speaker buttons call the store actions; Sonos branch keeps its `deviceId` guard, drag-timestamp update, and `sonosSetVolume` call.
- 9 new store tests (player.test.ts 19 → 28).

## Verification
- `pnpm verify` green (hub + frontend suites, 142 frontend tests, typecheck, boundary lint).
- `pnpm lint` zero errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwwPcrohddTUN7kmQVedQC