### PR TITLE
fix: restore local volume on unmute

### DIFF
--- a/frontend/src/components/player/PlayerBar.test.tsx
+++ b/frontend/src/components/player/PlayerBar.test.tsx
@@ -109,6 +109,52 @@ describe("PlayerBar render stability", () => {
   });
 });
 
+describe("PlayerBar local volume", () => {
+  it("restores the previous local volume when unmuting from zero", () => {
+    usePlayer.setState({
+      queue: [track("trk-1")],
+      currentIndex: 0,
+      volume: 0.36,
+    });
+
+    const { getByRole } = render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}><MemoryRouter>
+        <PlayerBar />
+      </MemoryRouter></QueryClientProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Mute" }));
+    });
+    expect(usePlayer.getState().volume).toBe(0);
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Unmute" }));
+    });
+    expect(usePlayer.getState().volume).toBe(0.36);
+  });
+
+  it("uses a halfway local volume when unmuting without a previous volume", () => {
+    usePlayer.setState({
+      queue: [track("trk-1")],
+      currentIndex: 0,
+      volume: 0,
+    });
+
+    const { getByRole } = render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}><MemoryRouter>
+        <PlayerBar />
+      </MemoryRouter></QueryClientProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(getByRole("button", { name: "Unmute" }));
+    });
+
+    expect(usePlayer.getState().volume).toBe(0.5);
+  });
+});
+
 describe("PlayerBar cast volume slider", () => {
   beforeEach(() => {
     vi.spyOn(api, "getCapabilities").mockResolvedValue({

--- a/frontend/src/components/player/PlayerBar.tsx
+++ b/frontend/src/components/player/PlayerBar.tsx
@@ -31,6 +31,8 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/cn";
 
+const DEFAULT_LOCAL_UNMUTE_VOLUME = 0.5;
+
 export function PlayerBar() {
   const navigate = useNavigate();
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -67,6 +69,13 @@ export function PlayerBar() {
       : null;
 
   const isSonos = sink !== "local";
+  const lastLocalVolumeRef = useRef(
+    volume > 0 ? volume : DEFAULT_LOCAL_UNMUTE_VOLUME,
+  );
+
+  useEffect(() => {
+    if (volume > 0) lastLocalVolumeRef.current = volume;
+  }, [volume]);
 
   // Capabilities drive whether the DevicePicker renders. Use `useQuery` so the
   // admin flipping `sonosAllowNonAdmin` (SonosSection invalidates
@@ -903,7 +912,7 @@ export function PlayerBar() {
           <>
             <button
               aria-label={volume === 0 ? "Unmute" : "Mute"}
-              onClick={() => setVolume(volume > 0 ? 0 : 0.8)}
+              onClick={() => setVolume(volume > 0 ? 0 : lastLocalVolumeRef.current)}
               className="p-1 text-text-muted hover:text-text-primary transition-colors"
             >
               {volume === 0 ? (


### PR DESCRIPTION
## Summary
Restore the local player's previous non-zero volume when the speaker button unmutes from zero, instead of jumping to the hardcoded 0.8 value.

## Root cause
The local volume button used `setVolume(volume > 0 ? 0 : 0.8)`, so any unmute from zero ignored the user's previous slider position.

## Changes
- Track the last non-zero local volume while `PlayerBar` is mounted.
- Fall back to `0.5` when unmuting with no previous non-zero value.
- Add regression coverage for both previous-volume restore and no-history fallback.

## Testing
- `corepack pnpm --filter frontend test -- PlayerBar.test.tsx` (fails before the fix with 0.8, passes after: 22 tests / 123 frontend collected tests passed)
- `corepack pnpm --filter frontend typecheck` (pass)
- `corepack pnpm --filter frontend lint:boundary` (pass)
- `corepack pnpm --filter frontend lint` (pass)
- `corepack pnpm --filter frontend test` (pass: 18 files / 123 tests)
- `git diff --check` (pass)

Note: the root `pnpm verify` script cannot run directly in this environment because nested scripts call a non-executable `pnpm` shim, so I ran the equivalent commands through `corepack pnpm`. The unchanged hub unit suite was also checked; `test/admin-routes.test.ts` consistently times out in `admin — sync > POST /api/admin/hub/sync → returns 200 with local + peers result shape`, unrelated to this frontend-only volume change.

Fixes #207