### PR TITLE
docs+ci: resolve conflicting agent instructions, make `pnpm verify` match CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Boundary lint (Hub/Player directory boundary, #221)
         run: pnpm lint:boundary
 
+      - name: Lint
+        run: pnpm lint
+
       - name: Unit tests
         run: pnpm test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,44 +9,51 @@ Poutine: federated music player. Hub (Fastify + SQLite) bundles an internal Navi
 ## Task tracking (GitHub Issues)
 
 1. Never start coding without an open GitHub Issue. No exceptions. Create one if none exists.
-2. Close the issue immediately after committing, before anything else.
-3. Check existing issues before creating new ones: `gh issue list --repo benders/poutine`
-4. Post progress updates as comments on the issue as you work. Agent comments must include the agent name prefix (e.g. `@claude:`), and the rest of the message should be a block-quote `> `.
-5. When unsure what's next, check open issues — don't freelance.
-6. Reference the issue number in the commit message (e.g. `closes #42`)
-7. Assign the issue to self when work starts
+2. Check existing issues before creating new ones: `gh issue list --repo benders/poutine`
+3. Assign the issue to self when work starts.
+4. Reference the issue in the commit message (e.g. `closes #42`). **The issue closes when the PR merges** — never close it by hand at commit time. Work isn't done until it is reviewed and merged.
+5. Post progress updates as comments on the issue as you work. Agent comments must include the agent name prefix (e.g. `@claude:`), and the rest of the message should be a block-quote `> `.
+6. When unsure what's next, check open issues — don't freelance.
+
+## Branching and commits
+
+- **Work on a feature branch.** Branch before the first edit. Never commit to `main` unless the user explicitly asks for that in this session.
+- Direct-to-`main` work, when the user does ask for it: make the change and run the gate, then stop. Committing and pushing on `main` need their own explicit ask — never do either automatically.
+- Commit in phases, as each phase's tests pass — not one lump at the end.
+- Push the branch to origin, then open a Pull Request in **Draft** state when the work is ready for the user to review.
+- **No stacked PRs.** Work identified during review lands on the same feature branch.
 
 ## Per-task checklist
 
 1. **Start every task by reading `docs/system-architecture.md` and skimming `docs/pitfalls.md`.** Both are short by design. No exceptions.
-2. Open or assign a GitHub Issue.
+2. Open or assign a GitHub Issue; create the feature branch.
 3. Read the relevant doc(s):
    - Touching auth, JWT, login, tokens, or Subsonic credentials: read `docs/authentication.md` FIRST.
    - Touching `/federation/*`: read `docs/federation-api.md` FIRST. Update it AND bump `FEDERATION_API_VERSION` in `hub/src/version.ts` on any contract change.
    - Touching hub internals, conventions, or anything with a known gotcha: check `docs/hub-internals.md`.
-   - Touching Player code (Sonos, DLNA, cast, player-admin): obey the **Hub/Player boundary** (section below) and run `pnpm lint:boundary`.
+   - Touching Player code (Sonos, DLNA, cast, player-admin): obey the **Hub/Player boundary** (section below).
    - Architectural changes: update `docs/system-architecture.md` as part of the work.
-4. Write tests alongside code. Run `pnpm verify` (typecheck + lint:boundary + unit tests) before declaring done.
+4. Write tests alongside code. Run `pnpm verify` before declaring done — it is the full local gate (typecheck + lint + unit tests + hub integration tests) and matches CI's `unit` job. Resolve **all** lint errors AND warnings, including pre-existing ones in files you didn't author; zero lint output is the bar. If a warning is a deliberate false-positive, suppress it inline with a one-line rationale rather than leaving it noisy.
    - **Touching the Subsonic API (`/rest/*`, `getAlbumList2`, scrobble/play-counts, search, stream), `/federation/*`, auth, or the merged-catalog shape? `pnpm verify` is NOT enough** — it does not run the Python `subsonic-compat` suite. Run `pnpm test:federation` (Docker; spins up hub-a/b/c) and get a green run before declaring done. `pnpm verify:full` runs both. CI gates every PR on the `federation` job regardless, so a skip here only delays the failure to post-push.
    - When querying the live database: check `hub/src/db/schema.sql` for the schema, then use `scripts/db-query.sh "SQL"`. Never exec into the container and try to import `better-sqlite3` manually.
-   - Run `pnpm lint` and resolve **all** errors AND warnings before declaring done — including pre-existing ones in files you didn't author. Zero lint output is the bar. If a warning is a deliberate false-positive, suppress it inline with a one-line rationale rather than leaving it noisy.
 5. Update documentation and check for any outdated or inconsistent information.
-6. Commit work in phases, when all tests are passing.
-7. Push branch to origin.
-8. When work is completed, open a Pull Request in the Draft state.
+6. Commit, push, and open a Draft PR — see **Branching and commits** above.
 
 ## Hub/Player boundary
 
-The backend is split into two bounded contexts inside one process — **Hub** (library, catalog, federation, users, hub-admin) and **Player** (Sonos cast, DLNA, player-admin) — so Player can later be lifted into its own process as a wiring change, not a rewrite (#212/#225). The split is real and machine-enforced. Do not erode it.
+The backend is two bounded contexts inside one process — **Hub** (library, catalog, federation, users, hub-admin) and **Player** (Sonos cast, DLNA, player-admin) — so Player can later be lifted into its own process as a wiring change, not a rewrite (#212/#225). The split is machine-enforced. Do not erode it.
 
-- **Player-side code** = `hub/src/routes/{sonos,dlna}.ts`, `hub/src/services/{sonos-*,dlna-*,cast-tokens,didl,soap,ssdp-advertiser,player-settings}.ts`, and frontend `features/player-admin/` + `features/player/`.
-- **Player code reaches Hub state only through `HubSubsonicCaller`** (`hub/src/services/hub-subsonic-caller.ts`) over `app.inject()`. It must NOT import `better-sqlite3` at runtime (type-only `import type Database` is fine), the in-process `SubsonicClient` (`adapters/subsonic`), `app.db`, or any `hub/src/db/*` module. Player-owned storage is `player.db` via a capability-injected handle (`app.playerDb` / `PlayerSettings` / `app.sonosSettings`), never `hub.db`.
-- **Frontend bounded dirs may not cross-import.** `features/hub-admin/`, `features/player-admin/`, and `features/player/` are isolated; shared pure-UI helpers go in `features/shared/`.
-- **Backend admin mounts are partitioned** (#226): `/api/admin/hub/*` (Hub) and `/api/admin/player/*` (Player); `/admin/*` is auth-only. Handlers mount only in their namespace — cross-namespace requests 404.
-- **Adding a Player route/service?** Add the file to the `playerFiles` glob in `hub/eslint.config.js` (and the frontend equivalent for UI), then extend the negative tests so the rule is proven to fire: `hub/test/boundary-lint.test.ts`, `frontend/src/features/boundary-lint.test.ts`. If an exception is unavoidable, document the carve-out inline in the config — never silently relax the rule.
-- **Test it:** run `pnpm lint:boundary` (also bundled into `pnpm verify` and CI). Zero output is the bar — a boundary violation is a build failure, not a warning.
+Rules:
 
-Full rationale and enforcement matrix: `docs/system-architecture.md` ("Hub/Player boundary enforcement", "SPA admin split", "Data model" dual-DB). Recurring traps: `docs/pitfalls.md` ("Hub/Player boundary", "Sonos cast"). Boundary test patterns: `docs/frontend-testing.md`. The trusted in-process auth path Player uses to call Hub Subsonic as the SPA user: `docs/authentication.md` ("Trusted in-process auth").
+- **Player code reaches Hub state only through `HubSubsonicCaller`** (`hub/src/services/hub-subsonic-caller.ts`). Never widen that door.
+- **Neither side touches the other's SQLite file.** Player-owned storage is `player.db` via the capability-injected handle (`app.playerDb` / `PlayerSettings` / `app.sonosSettings`); Hub-owned storage is `hub.db`.
+- **Bounded directories may not cross-import** — backend Player files, and frontend `features/hub-admin/`, `features/player-admin/`, `features/player/`. Shared pure-UI helpers go in `features/shared/`.
+- **Handlers mount only in their own admin namespace** — `/api/admin/hub/*` (Hub), `/api/admin/player/*` (Player), `/admin/*` auth-only.
+- **Adding a Player route or service?** Add the file to the `playerFiles` glob in `hub/eslint.config.js` (and the frontend equivalent for UI), then extend the negative tests so the rule is proven to fire: `hub/test/boundary-lint.test.ts`, `frontend/src/features/boundary-lint.test.ts`.
+- **An unavoidable exception is documented inline in the eslint config** — never silently relaxed.
+- **Test it:** `pnpm lint:boundary` isolates just these rules (`pnpm verify` and CI run them too). Zero output is the bar — a boundary violation is a build failure, not a warning.
+
+Architecture, the full file lists, and the enforcement matrix: `docs/system-architecture.md` ("Hub/Player boundary enforcement", "SPA admin split", "Data model" dual-DB). Recurring traps: `docs/pitfalls.md` ("Hub/Player boundary", "Sonos cast"). Boundary test patterns: `docs/frontend-testing.md`. The trusted in-process auth path Player uses to call Hub Subsonic as the SPA user: `docs/authentication.md` ("Trusted in-process auth").
 
 ## Documentation rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,6 @@ When posting comments, ALWAYS prefix comments with `FROM @claude:` and use block
 
 ### Tool gotchas
 
-* The Write tool can emit literal control characters for `\u0000`–`\u001f` escapes inside regex character classes; a later Edit `old_string` then never matches. Repair the bytes with `perl -i -pe`. (Hit twice.)
+* **A `\uXXXX` escape in a tool argument is decoded before the tool sees it.** Every tool argument arrives as a JSON string, so documenting a C0 control character (U+0000–U+001F) — in a regex character class, say — puts the *real* control byte in the file instead of the six characters you meant. It is invisible in a terminal, and a later Edit `old_string` carrying the visible form then never matches. Double the backslash (`\\uXXXX`) to emit literal text. Not Write-specific: Write, Edit and Bash all decode, though Bash is rejected outright with "command contains control characters" — the cheap way to find out. Repair bytes already on disk with `perl -i -pe`: its regex matches raw bytes, which an Edit `old_string` cannot express. (Hit three times.)
 
 **DO NOT** put any rules in here unless it is unique to Claude Code. All other updates **MUST** go into either `AGENTS.md` or the relevant file in `docs/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 ## Claude Code
 
+Everything else — task tracking, branching, commits, the PR flow, the verify gate — lives in `AGENTS.md`.
+
 ### Posting to GitHub
 
 When posting comments, ALWAYS prefix comments with `FROM @claude:` and use blockquote style
@@ -9,19 +11,5 @@ When posting comments, ALWAYS prefix comments with `FROM @claude:` and use block
 ### Tool gotchas
 
 * The Write tool can emit literal control characters for `\u0000`–`\u001f` escapes inside regex character classes; a later Edit `old_string` then never matches. Repair the bytes with `perl -i -pe`. (Hit twice.)
-
-### Workflow
-
-Default flow should be to use Pull Requests.
-
-* Create a feature branch before starting work
-* Work in phases
-* Check documentation and tests after implementation to make sure they cover new behavior
-* Commit when tests pass and push branch to origin
-* Create a PR when it is ready for the user to review it. PR should be created in "Draft" state
-* DO NOT create "stacked" PRs. If new work is identified during review, it must be made directly onto the same feature branch
-
-At user's explicit direction, minor changes can be made directly to `main` branch
-* Never automatically commit when working on `main`
 
 **DO NOT** put any rules in here unless it is unique to Claude Code. All other updates **MUST** go into either `AGENTS.md` or the relevant file in `docs/`.

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ Leave `PUBLIC_DIR` unset in dev so the hub does not attempt to serve static file
 |-----------------------------|-------------------------------------------------|
 | `pnpm dev`                  | Start hub in watch mode                         |
 | `pnpm build`                | Build hub + frontend                            |
-| `pnpm test`                 | Run hub unit tests (vitest)                     |
+| `pnpm test`                 | Run hub + frontend unit tests (vitest)          |
+| `pnpm test:integration`     | Hub integration tests (merge-worker, DLNA/SSDP) |
 | `pnpm test:federation`      | Three-hub federation integration test           |
 | `pnpm lint`                 | Lint both packages (must report zero output)    |
-| `pnpm lint:boundary`        | Boundary-only lint subset (used by CI / verify) |
+| `pnpm lint:boundary`        | Boundary-only lint subset (isolated CI signal)  |
 | `pnpm typecheck`            | Typecheck both packages                         |
-| `pnpm verify`               | Typecheck + lint:boundary + unit test (pre-commit gate) |
+| `pnpm verify`               | Typecheck + lint + unit + integration tests — the pre-commit gate; matches CI's `unit` job |
 | `pnpm verify:full`          | `verify` + `test:federation` (for Subsonic/federation changes) |
 | `pnpm hub:up`               | `docker compose up -d --build`                  |
 | `pnpm hub:up:fresh`         | Same, with `--force-recreate`                   |
@@ -53,8 +54,8 @@ Leave `PUBLIC_DIR` unset in dev so the hub does not attempt to serve static file
 ## Testing
 
 - `pnpm test` — fast unit tests (vitest). CI runs this (the `unit` job).
+- `pnpm test:integration` — hub `*.integration.test.ts` (merge-worker, DLNA SOAP/SSDP). Real sockets and UDP multicast, so a host without multicast (or without macOS local-network permission for the terminal) sees flakes. CI runs this in the `unit` job.
 - `pnpm test:federation` — three-hub federation integration test, incl. the Python `subsonic-compat` suite. Boots three Compose projects, verifies cross-instance dedup, federated streaming, and Subsonic-client compatibility. **CI runs this on every PR** (the `federation` job), and `pnpm verify` does NOT cover it — run it locally (or `pnpm verify:full`) when changing the Subsonic API or federation surface.
-- `*.integration.test.ts` — excluded from CI; hit real external servers. Run manually.
 
 See [docs/hub-internals.md#testing-notes](docs/hub-internals.md#testing-notes) for test patterns and gotchas.
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "pnpm --filter hub lint && pnpm --filter frontend lint",
     "lint:boundary": "pnpm --filter hub lint:boundary && pnpm --filter frontend lint:boundary",
     "typecheck": "pnpm --filter hub typecheck && pnpm --filter frontend typecheck",
-    "verify": "pnpm typecheck && pnpm lint:boundary && pnpm test",
+    "verify": "pnpm typecheck && pnpm lint && pnpm test && pnpm test:integration",
     "verify:full": "pnpm verify && pnpm test:federation",
     "test:integration": "pnpm --filter hub test:integration",
     "hub:up": "docker compose up -d --build",


### PR DESCRIPTION
Closes #267.

Five instruction conflicts, each of which could send an agent the wrong way, plus a local gate that was weaker than CI.

### a. Issues close on merge
`AGENTS.md` told agents to close the issue "immediately after committing" while also writing `closes #N` and ending in a **Draft** PR — that closes issues while review is still pending. Now: reference `closes #N`, let the merge do it, never hand-close at commit time.

### b. AGENTS.md no longer duplicates the architecture
Its own §Documentation rules forbid architecture in the file, but §Hub/Player boundary carried ~20 lines lifted from `docs/system-architecture.md` — including a second copy of the `playerFiles` glob list, which would have drifted. Reduced to seven rule lines; architecture referenced by path.

### c. CLAUDE.md holds only Claude-unique rules
Its §Workflow was general process, duplicating the `AGENTS.md` checklist against its own closing rule. Removed; `FROM @claude:` and the Write-tool control-character gotcha stay.

### d. Commit rules consolidated
New `AGENTS.md` §Branching and commits. Feature branch is the default. Direct-to-`main` needs an explicit ask, and committing or pushing there each need their own — the old wording let the checklist's unconditional "commit in phases" override `CLAUDE.md`'s "never automatically commit on `main`".

### e. `pnpm verify` matches CI

| | before | after |
|---|---|---|
| `pnpm verify` | typecheck + `lint:boundary` + test | typecheck + **lint** + test + **test:integration** |
| CI `unit` job | typecheck + `lint:boundary` + test + test:integration | + **lint** |

A green `verify` could previously still fail CI two ways: full-lint warnings (which `AGENTS.md` demanded separately, three bullets deep) and `test:integration`. Full lint subsumes the boundary rules; `lint:boundary` stays a separate script so CI keeps an isolated boundary signal.

### Verification

Typecheck, full lint (zero output), 166 frontend + hub unit tests, and integration tests all green locally. The first run hit one integration failure — a pre-existing SSDP multicast flake, ~1 run in 3, unrelated to this change and filed as #268.

Not in this PR: the documentation-drift findings from the same review (stale `/admin/activity/*` paths in `hub-internals.md`, the merge-worker gap in `system-architecture.md`). Those get their own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6d5j3DE1sqf6Gm34gEAAN